### PR TITLE
Swagger API & Manipulate + Accessibility Statistics Page

### DIFF
--- a/api/accessibility/contrast.ts
+++ b/api/accessibility/contrast.ts
@@ -10,7 +10,7 @@ const levels = ["minimum", "enhanced"] as ("minimum" | "enhanced")[];
 
 /**
  * @swagger
- * /api/contrast:
+ * /api/accessibility/contrast:
  *   get:
  *     summary: Contrast & Readability information from two colors
  *     description: Obtain `contrast` and `readability` related information from `foreground` and `background` colors.

--- a/api/accessibility/statistics.ts
+++ b/api/accessibility/statistics.ts
@@ -1,0 +1,147 @@
+import { VercelRequest, VercelResponse } from "@vercel/node";
+import CM, { extendPlugins } from "colormaster";
+import A11yPlugin from "colormaster/plugins/accessibility";
+import NamePlugin from "colormaster/plugins/name";
+
+extendPlugins([A11yPlugin, NamePlugin]);
+
+/**
+ * @swagger
+ * /api/accessibility/statistics:
+ *   get:
+ *     summary: Provides various accessibility statistics for a given input color
+ *     description: Provides the `brightness`, `luminance` and whether the color is `light/dark`, `warm/cool`, `tinted/shaded/toned`, or `pure hue`. Additionally, returns the closest `warm`, `cool`, `pure hue`, and `web safe` colors.
+ *
+ *     tags:
+ *       - ColorMaster
+ *
+ *     parameters:
+ *       - in: query
+ *         name: color
+ *         required: true
+ *         description: The current color instance whose statistics will be computer
+ *         default: dfaf20ff
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: alpha
+ *         required: false
+ *         description: For each of the closest `warm`, `cool`, `pure hue`, and `web safe` colors, should the alpha channel be included?
+ *         default: '[true,true,true,true]'
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Accessibility statistics for the input color.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 color:
+ *                   type: string
+ *                   example: 'dfaf20ff'
+ *                 colorName:
+ *                   type: string
+ *                   example: 'golden rod'
+ *                 warm:
+ *                   type: string
+ *                   example: 'dfaf20ff'
+ *                 warmName:
+ *                   type: string
+ *                   example: 'golden rod'
+ *                 cool:
+ *                   type: string
+ *                   example: 'afdf20ff'
+ *                 coolName:
+ *                   type: string
+ *                   example: 'green yellow'
+ *                 pure:
+ *                   type: string
+ *                   example: 'ffbf00ff'
+ *                 pureName:
+ *                   type: string
+ *                   example: 'gold'
+ *                 web:
+ *                   type: string
+ *                   example: 'cc9933ff'
+ *                 webName:
+ *                   type: string
+ *                   example: 'peru'
+ *                 alpha:
+ *                   type: array
+ *                   example: [true,true,true,true]
+ *                 brightness:
+ *                   type: float
+ *                   example: 0.6786
+ *                 luminance:
+ *                   type: float
+ *                   example: 0.4645
+ *                 lightOrDark:
+ *                   type: string
+ *                   example: 'light'
+ *                 warmOrCool:
+ *                   type: string
+ *                   example: 'warm'
+ *                 pureHue:
+ *                   type: object
+ *                   properties:
+ *                     pure:
+ *                       type: boolean
+ *                       example: true
+ *                     reason:
+ *                       type: string
+ *                       example: "toned"
+ *       400:
+ *         description: Bad data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 'Invalid data provided'
+ */
+module.exports = (req: VercelRequest, res: VercelResponse) => {
+  const { color, alpha: a } = req.query as { [key: string]: string };
+
+  const alpha = a ? JSON.parse(a) : new Array(4).fill(true);
+  const warm = CM(color).closestWarm().stringHEX({ alpha: alpha[0] }).slice(1).toLowerCase();
+  const cool = CM(color).closestCool().stringHEX({ alpha: alpha[1] }).slice(1).toLowerCase();
+  const pure = CM(color).closestPureHue().stringHEX({ alpha: alpha[2] }).slice(1).toLowerCase();
+  const web = CM(color).closestWebSafe().stringHEX({ alpha: alpha[3] }).slice(1).toLowerCase();
+
+  const brightness = CM(color).brightness();
+  const luminance = CM(color).luminance();
+  const lightOrDark = CM(color).isLight() ? "light" : "dark";
+  const warmOrCool = CM(color).isWarm() ? "warm" : "cool";
+  const pureHue = CM(color).isPureHue();
+
+  if (CM(color).isValid()) {
+    const [colorName, warmName, coolName, pureName, webName] = [color, warm, cool, pure, web].map((c) =>
+      CM(c).name({ exact: false })
+    );
+
+    res.json({
+      color,
+      colorName,
+      warm,
+      warmName,
+      cool,
+      coolName,
+      pure,
+      pureName,
+      web,
+      webName,
+      alpha,
+      brightness,
+      luminance,
+      lightOrDark,
+      warmOrCool,
+      pureHue
+    });
+  } else {
+    res.status(400).json({ error: "Invalid data provided" });
+  }
+};

--- a/api/contrast.ts
+++ b/api/contrast.ts
@@ -22,28 +22,28 @@ const levels = ["minimum", "enhanced"] as ("minimum" | "enhanced")[];
  *       - in: query
  *         name: fgColor
  *         required: true
- *         description: The foreground color (text on top of background)
+ *         description: The **foreground color** (text on top of background)
  *         default: ffff00ff
  *         schema:
  *           type: string
  *       - in: query
  *         name: bgColor
  *         required: true
- *         description: The background color (behind the text)
+ *         description: The **background color** (behind the text)
  *         default: 0000ffff
  *         schema:
  *           type: string
  *       - in: query
  *         name: ratio
  *         required: false
- *         description: Whether or not to add ":1" to the contrast
+ *         description: Whether or not to add **:1** to the contrast
  *         default: true
  *         schema:
  *           type: boolean
  *       - in: query
  *         name: size
  *         required: false
- *         description: body or large - indicating the text size
+ *         description: "`body` or `large` indicating the text size"
  *         default: large
  *         schema:
  *           type: string

--- a/api/contrast.ts
+++ b/api/contrast.ts
@@ -8,6 +8,96 @@ extendPlugins([A11yPlugin, NamePlugin]);
 const sizes = ["body", "large"] as ("body" | "large")[];
 const levels = ["minimum", "enhanced"] as ("minimum" | "enhanced")[];
 
+/**
+ * @swagger
+ * /api/contrast:
+ *   get:
+ *     summary: Contrast & Readability information from two colors
+ *     description: Obtain `contrast` and `readability` related information from `foreground` and `background` colors.
+ *
+ *     tags:
+ *       - ColorMaster
+ *
+ *     parameters:
+ *       - in: query
+ *         name: fgColor
+ *         required: true
+ *         description: The foreground color (text on top of background)
+ *         default: ffff00ff
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: bgColor
+ *         required: true
+ *         description: The background color (behind the text)
+ *         default: 0000ffff
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: ratio
+ *         required: false
+ *         description: Whether or not to add ":1" to the contrast
+ *         default: true
+ *         schema:
+ *           type: boolean
+ *       - in: query
+ *         name: size
+ *         required: false
+ *         description: body or large - indicating the text size
+ *         default: large
+ *         schema:
+ *           type: string
+ *
+ *     responses:
+ *       200:
+ *         description: Foreground & Background colors, their names, contrast, and readability information.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 fgColor:
+ *                   type: string
+ *                   example: 'ffff00ff'
+ *                 fgColorName:
+ *                   type: string
+ *                   example: 'yellow'
+ *                 bgColor:
+ *                   type: string
+ *                   example: '0000ffff'
+ *                 bgColorName:
+ *                   type: string
+ *                   example: 'blue'
+ *                 contrast:
+ *                   type: string
+ *                   example: '8.0016:1'
+ *                 readableOn:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       size:
+ *                         type: string
+ *                         example: 'body'
+ *                       level:
+ *                         type: string
+ *                         example: 'minimum'
+ *                       readable:
+ *                         type: boolean
+ *                 ratio:
+ *                   type: boolean
+ *                   example: true
+ *       400:
+ *         description: Bad data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 'Invalid data provided'
+ */
 module.exports = (req: VercelRequest, res: VercelResponse) => {
   const { fgColor, bgColor, ratio: r } = req.query as { [key: string]: string };
 

--- a/api/contrast.ts
+++ b/api/contrast.ts
@@ -15,8 +15,8 @@ module.exports = (req: VercelRequest, res: VercelResponse) => {
 
   if (CM(fgColor).isValid() && CM(bgColor).isValid()) {
     const contrast = CM(fgColor).contrast({ bgColor, ratio });
-    const readableOn = sizes.map((s) =>
-      levels.map((l) => ({ size: s, ratio: l, readable: CM(fgColor).readableOn({ bgColor, size: s, ratio: l }) }))
+    const readableOn = sizes.flatMap((s) =>
+      levels.map((l) => ({ size: s, level: l, readable: CM(fgColor).readableOn({ bgColor, size: s, level: l }) }))
     );
 
     const [fgColorName, bgColorName] = [fgColor, bgColor].map((c) => CM(c).name({ exact: false }));

--- a/api/harmony.ts
+++ b/api/harmony.ts
@@ -19,6 +19,94 @@ const validTypes = [
 
 const validEffects = ["tints", "shades", "tones"];
 
+/**
+ * @swagger
+ * /api/harmony:
+ *   get:
+ *     summary: Color harmonies from an input color
+ *     description: "Given a `type` with (optionally - for monochromatic types) `effect` & `amount`, returns the related color harmony group for the input color. See [color harmonies](https://www.canva.com/colors/color-wheel/) for more details"
+ *
+ *     tags:
+ *       - ColorMaster
+ *
+ *     parameters:
+ *       - in: query
+ *         name: color
+ *         required: true
+ *         description: The main color from which the harmony is determined
+ *         default: ffff00ff
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: type
+ *         required: true
+ *         description: "Harmony group type to find. One of: \"analogous\", \"complementary\", \"split-complementary\", \"double split-complementary\", \"triad\", \"rectangle\", \"square\", or \"monochromatic\""
+ *         default: analogous
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: effect
+ *         required: false
+ *         description: Only applies to monochromatic harmony type. Possible values are shades, tints, or tones
+ *         default: shades
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: amount
+ *         required: false
+ *         description: Only applies to monochromatic harmony type. Number of harmony colors to return - in range [2, 10]
+ *         default: 5
+ *         schema:
+ *           type: integer
+ *
+ *     responses:
+ *       200:
+ *         description: Relevant harmony information such as base color, its name, resulting harmony, and resulting harmony names
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 color:
+ *                   type: string
+ *                   example: 'ffff00ff'
+ *                 colorName:
+ *                   type: string
+ *                   example: 'yellow'
+ *                 result:
+ *                   type: array
+ *                   example: [
+ *                              "ff8000ff",
+ *                              "ffff00ff",
+ *                              "80ff00ff"
+ *                            ]
+ *                 resultName:
+ *                   type: array
+ *                   example: [
+ *                              "dark orange",
+ *                              "yellow",
+ *                              "chart reuse"
+ *                            ]
+ *                 type:
+ *                   type: string
+ *                   example: 'monochromatic'
+ *                 effect:
+ *                   type: string
+ *                   example: 'shades'
+ *                 amount:
+ *                   type: integer
+ *                   example: 5
+ *       400:
+ *         description: Bad data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 'Invalid data provided'
+ */
 module.exports = (req: VercelRequest, res: VercelResponse) => {
   const { color, type: t, effect: e, amount: a } = req.query as { [key: string]: string };
 

--- a/api/harmony.ts
+++ b/api/harmony.ts
@@ -40,21 +40,21 @@ const validEffects = ["tints", "shades", "tones"];
  *       - in: query
  *         name: type
  *         required: true
- *         description: "Harmony group type to find. One of: \"analogous\", \"complementary\", \"split-complementary\", \"double split-complementary\", \"triad\", \"rectangle\", \"square\", or \"monochromatic\""
+ *         description: "Harmony group type to find. One of: `analogous`, `complementary`, `split-complementary`, `double split-complementary`, `triad`, `rectangle`, `square`, or `monochromatic`"
  *         default: analogous
  *         schema:
  *           type: string
  *       - in: query
  *         name: effect
  *         required: false
- *         description: Only applies to monochromatic harmony type. Possible values are shades, tints, or tones
+ *         description: Only applies to **monochromatic** harmony type. Possible values are `shades`, `tints`, or `tones`
  *         default: shades
  *         schema:
  *           type: string
  *       - in: query
  *         name: amount
  *         required: false
- *         description: Only applies to monochromatic harmony type. Number of harmony colors to return - in range [2, 10]
+ *         description: Only applies to **monochromatic** harmony type. Number of harmony colors to return - in range [2, 10]
  *         default: 5
  *         schema:
  *           type: integer

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,36 @@
+import express from "express";
+import swaggerJSDoc from "swagger-jsdoc";
+import swaggerUi from "swagger-ui-express";
+import { version } from "../package.json";
+
+const app = express();
+app.use(express.json());
+
+const swaggerSpec = swaggerJSDoc({
+  swaggerDefinition: {
+    openapi: "3.0.0",
+    info: {
+      title: "ColorMaster's API",
+      description:
+        "This API highlights the main functionality of ColorMaster. You can find out more information at [NPM - ColorMaster](https://www.npmjs.com/package/colormaster)",
+      version,
+      license: {
+        name: "MIT License",
+        url: "https://github.com/lbragile/ColorMaster/blob/master/LICENSE.md"
+      },
+      contact: {
+        email: "lbragile.masc@gmail.com"
+      }
+    },
+    externalDocs: {
+      description: "Codebase Documentation",
+      url: "https://lbragile.github.io/ColorMaster/"
+    },
+    tags: [{ name: "ColorMaster", description: "Routes for main functionality" }]
+  },
+  apis: ["api/*"]
+});
+
+app.use("/api", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+module.exports = app;

--- a/api/manipulate.ts
+++ b/api/manipulate.ts
@@ -87,7 +87,7 @@ extendPlugins([NamePlugin]);
  *
  *     responses:
  *       200:
- *         description: Relevant harmony information such as base color, its name, resulting harmony, and resulting harmony names
+ *         description: Information regarding the manipulation of the input `color` based on the relevant increment/decrement parameters
  *         content:
  *           application/json:
  *             schema:
@@ -101,19 +101,19 @@ extendPlugins([NamePlugin]);
  *                   example: 'yellow (with opacity)'
  *                 adjust:
  *                   type: string
- *                   example: '33FF5C8D'
+ *                   example: '33ff5C8D'
  *                 adjustName:
  *                   type: string
  *                   example: 'spring green (with opacity)'
  *                 rotate:
  *                   type: string
- *                   example: '00FF3380'
+ *                   example: '00ff3380'
  *                 rotateName:
  *                   type: string
  *                   example: 'lime (with opacity)'
  *                 invert:
  *                   type: string
- *                   example: '0000FF7F'
+ *                   example: '0000ff7f'
  *                 invertName:
  *                   type: string
  *                   example: 'blue (with opacity)'
@@ -163,15 +163,17 @@ module.exports = (req: VercelRequest, res: VercelResponse) => {
     const rotate = CM(color)
       .rotate(sign * hueBy)
       .stringHEX({ alpha: alpha[1] })
-      .slice(1);
+      .slice(1)
+      .toLowerCase();
     const adjust = CM(rotate)
       .alphaBy(sign * alphaBy)
       .saturateBy(sign * satBy)
       .lighterBy(sign * lightBy)
       .stringHEX({ alpha: alpha[0] })
-      .slice(1);
-    const invert = CM(color).invert({ alpha: alpha[2] }).stringHEX({ alpha: alpha[2] }).slice(1);
-    const grayscale = CM(color).grayscale().stringHEX({ alpha: alpha[3] }).slice(1);
+      .slice(1)
+      .toLowerCase();
+    const invert = CM(color).invert({ alpha: alpha[2] }).stringHEX({ alpha: alpha[2] }).slice(1).toLowerCase();
+    const grayscale = CM(color).grayscale().stringHEX({ alpha: alpha[3] }).slice(1).toLowerCase();
 
     const [colorName, adjustName, rotateName, invertName, grayscaleName] = [
       color,

--- a/api/manipulate.ts
+++ b/api/manipulate.ts
@@ -6,7 +6,7 @@ extendPlugins([NamePlugin]);
 
 /**
  * @swagger
- * /api/manipulation:
+ * /api/manipulate:
  *   get:
  *     summary: Various manipulations of an input color
  *     description: "Given an \"increment color\" (via `hueBy`, `satBy`, `lightBy`, and `alphaBy`), returns 4 new colors:

--- a/api/manipulation.ts
+++ b/api/manipulation.ts
@@ -1,0 +1,201 @@
+import { VercelRequest, VercelResponse } from "@vercel/node";
+import CM, { extendPlugins } from "colormaster";
+import NamePlugin from "colormaster/plugins/name";
+
+extendPlugins([NamePlugin]);
+
+/**
+ * @swagger
+ * /api/manipulation:
+ *   get:
+ *     summary: Various manipulations of an input color
+ *     description: "Given an \"increment color\" (via `hueBy`, `satBy`, `lightBy`, and `alphaBy`), returns 4 new colors:
+ *
+ *                   ### 1. **Adjust**
+ *
+ *                   Input color + increment color (channel wise)
+ *
+ *                   ### 2. **Rotate**
+ *
+ *                   Input color + increment color's hue ONLY
+ *
+ *                   ### 3. **Invert**
+ *
+ *                   Input color hue + 180&deg; &amp; flip input color lightness. This also takes into account `alpha[2]` (flip alpha channel value?).
+ *                   In RGB space this would be the same as assigning each channel → **255 - channel value**
+ *
+ *                   ### 4. **Grayscale**
+ *
+ *                   Input color **saturation = 0%** (completely desaturate). Changes are visible only when lightness of input color is modified
+ *                  "
+ *
+ *     tags:
+ *       - ColorMaster
+ *
+ *     parameters:
+ *       - in: query
+ *         name: color
+ *         required: true
+ *         description: The color from which all the manipulation colors, described above, are computed
+ *         default: ffff0080
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: isIncrement
+ *         required: false
+ *         description: Whether to add or subtract `hueBy`, `satBy`, `lightBy`, &amp; `alphaBy` to/from `color`
+ *         default: true
+ *         schema:
+ *           type: boolean
+ *       - in: query
+ *         name: hueBy
+ *         required: false
+ *         description: How much to increment/decrement the hue of `color`
+ *         default: 72.0
+ *         schema:
+ *           type: float
+ *       - in: query
+ *         name: satBy
+ *         required: false
+ *         description: How much to increment/decrement the saturation of `color`
+ *         default: 15.0
+ *         schema:
+ *           type: float
+ *       - in: query
+ *         name: lightBy
+ *         required: false
+ *         description: How much to increment/decrement the lightness of `color`
+ *         default: 10
+ *         schema:
+ *           type: float
+ *       - in: query
+ *         name: alphaBy
+ *         required: false
+ *         description: How much to increment/decrement the alpha of `color` (expressed as percentage)
+ *         default: 5
+ *         schema:
+ *           type: float
+ *       - in: query
+ *         name: alpha
+ *         required: false
+ *         description: "Whether or not to include alpha channels in the manipulation colors.
+ *                       Each index corresponds to the respectively numbered manipulation color above.
+ *                       For `invert` this also indicates if the alpha channel should also be flipped."
+ *         default: "[true, true, true, true]"
+ *         schema:
+ *           type: string
+ *
+ *     responses:
+ *       200:
+ *         description: Relevant harmony information such as base color, its name, resulting harmony, and resulting harmony names
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 color:
+ *                   type: string
+ *                   example: 'ffff0080'
+ *                 colorName:
+ *                   type: string
+ *                   example: 'yellow (with opacity)'
+ *                 adjust:
+ *                   type: string
+ *                   example: '33FF5C8D'
+ *                 adjustName:
+ *                   type: string
+ *                   example: 'spring green (with opacity)'
+ *                 rotate:
+ *                   type: string
+ *                   example: '00FF3380'
+ *                 rotateName:
+ *                   type: string
+ *                   example: 'lime (with opacity)'
+ *                 invert:
+ *                   type: string
+ *                   example: '0000FF7F'
+ *                 invertName:
+ *                   type: string
+ *                   example: 'blue (with opacity)'
+ *                 grayscale:
+ *                   type: string
+ *                   example: '80808080'
+ *                 grayscaleName:
+ *                   type: string
+ *                   example: 'gray (with opacity)'
+ *                 isIncrement:
+ *                   type: boolean
+ *                   example: true
+ *                 alpha:
+ *                   type: array
+ *                   example: '[true, true, true, true]'
+ *       400:
+ *         description: Bad data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 'Invalid data provided'
+ */
+module.exports = (req: VercelRequest, res: VercelResponse) => {
+  const {
+    color,
+    hueBy: h,
+    satBy: s,
+    lightBy: l,
+    alphaBy: a,
+    isIncrement,
+    alpha: alphaArr
+  } = req.query as { [key: string]: string };
+
+  const hueBy = Number(h ?? 72);
+  const satBy = Number(s ?? 15);
+  const lightBy = Number(l ?? 10);
+  const alphaBy = a ? +a / 100 : 0.05;
+  const alpha = JSON.parse(alphaArr);
+
+  const sign = isIncrement === "true" ? 1 : -1;
+
+  if (CM(color).isValid()) {
+    const rotate = CM(color)
+      .rotate(sign * hueBy)
+      .stringHEX({ alpha: alpha[1] })
+      .slice(1);
+    const adjust = CM(rotate)
+      .alphaBy(sign * alphaBy)
+      .saturateBy(sign * satBy)
+      .lighterBy(sign * lightBy)
+      .stringHEX({ alpha: alpha[0] })
+      .slice(1);
+    const invert = CM(color).invert({ alpha: alpha[2] }).stringHEX({ alpha: alpha[2] }).slice(1);
+    const grayscale = CM(color).grayscale().stringHEX({ alpha: alpha[3] }).slice(1);
+
+    const [colorName, adjustName, rotateName, invertName, grayscaleName] = [
+      color,
+      adjust,
+      rotate,
+      invert,
+      grayscale
+    ].map((c) => CM(c).name({ exact: false }));
+
+    res.json({
+      color,
+      colorName,
+      adjust,
+      adjustName,
+      rotate,
+      rotateName,
+      invert,
+      invertName,
+      grayscale,
+      grayscaleName,
+      isIncrement,
+      alpha
+    });
+  } else {
+    res.status(400).json({ error: "Invalid color format" });
+  }
+};

--- a/api/mix.ts
+++ b/api/mix.ts
@@ -8,6 +8,89 @@ extendPlugins([MixPlugin, NamePlugin]);
 
 const validColorspace = ["rgb", "hex", "hsl", "hsv", "hwb", "lab", "lch", "luv", "uvw", "ryb", "cmyk", "xyz"];
 
+/**
+ * @swagger
+ * /api/mix:
+ *   get:
+ *     summary: Information from mixing two colors
+ *     description: Information from mixing two colors at a given `ratio` in `colorspace`.
+ *                  The colorspace can be any of the ones supported by ColorMaster.
+ *     tags:
+ *       - ColorMaster
+ *
+ *     parameters:
+ *       - in: query
+ *         name: primary
+ *         required: true
+ *         description: Original color that is used in the mixing process
+ *         default: ffff00ff
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: secondary
+ *         required: true
+ *         description: Another color to mix with the primary color
+ *         default: 0000ffff
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: ratio
+ *         required: false
+ *         description: The proportions to use when mixing the colors. Must be in range [0, 1]
+ *         default: 0.5
+ *         schema:
+ *           type: number
+ *       - in: query
+ *         name: colorspace
+ *         required: false
+ *         description: "A colorspace supported by [ColorMaster](https://www.npmjs.com/package/colormaster#-color-space-plugins). Mixing is performed in this colorspace."
+ *         default: luv
+ *         schema:
+ *           type: string
+ *
+ *     responses:
+ *       200:
+ *         description: Foreground & Background colors, their names, contrast, and readability information.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 primary:
+ *                   type: string
+ *                   example: 'ffff00ff'
+ *                 primaryName:
+ *                   type: string
+ *                   example: 'yellow'
+ *                 secondary:
+ *                   type: string
+ *                   example: '0000ffff'
+ *                 secondaryName:
+ *                   type: string
+ *                   example: 'blue'
+ *                 result:
+ *                   type: string
+ *                   example: "9898b4ff"
+ *                 resultName:
+ *                   type: string
+ *                   example: "dark gray"
+ *                 ratio:
+ *                   type: integer
+ *                   example: 0.5
+ *                 colorspace:
+ *                   type: string
+ *                   example: luv
+ *       400:
+ *         description: Bad data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 'Invalid data provided'
+ */
 module.exports = (req: VercelRequest, res: VercelResponse) => {
   const { primary, secondary, ratio: r, colorspace: c } = req.query as { [key: string]: string };
 

--- a/api/mix.ts
+++ b/api/mix.ts
@@ -39,7 +39,7 @@ const validColorspace = ["rgb", "hex", "hsl", "hsv", "hwb", "lab", "lch", "luv",
  *         description: The proportions to use when mixing the colors. Must be in range [0, 1]
  *         default: 0.5
  *         schema:
- *           type: number
+ *           type: float
  *       - in: query
  *         name: colorspace
  *         required: false

--- a/api/mix.ts
+++ b/api/mix.ts
@@ -50,7 +50,7 @@ const validColorspace = ["rgb", "hex", "hsl", "hsv", "hwb", "lab", "lch", "luv",
  *
  *     responses:
  *       200:
- *         description: Foreground & Background colors, their names, contrast, and readability information.
+ *         description: Results from the mixture obtained by mixing `primary` with `secondary` with proportions given by `ratio` in `colorspace`
  *         content:
  *           application/json:
  *             schema:

--- a/api/v1.ts
+++ b/api/v1.ts
@@ -1,12 +1,10 @@
 import express = require("express");
 import swaggerJSDoc = require("swagger-jsdoc");
 import swaggerUi = require("swagger-ui-express");
-import packageJSON = require("../package.json");
-import path = require("path");
+import { version } from "../package.json";
 
 const app = express();
 app.use(express.json());
-app.use(express.static(path.resolve(__dirname, "../", "public")));
 
 const swaggerSpec = swaggerJSDoc({
   swaggerDefinition: {
@@ -15,7 +13,7 @@ const swaggerSpec = swaggerJSDoc({
       title: "ColorMaster's API",
       description:
         "This API highlights the main functionality of ColorMaster. You can find out more information at [NPM - ColorMaster](https://www.npmjs.com/package/colormaster)",
-      version: packageJSON.version,
+      version,
       license: {
         name: "MIT License",
         url: "https://github.com/lbragile/ColorMaster/blob/master/LICENSE.md"

--- a/api/v1.ts
+++ b/api/v1.ts
@@ -1,10 +1,12 @@
-import express from "express";
-import swaggerJSDoc from "swagger-jsdoc";
-import swaggerUi from "swagger-ui-express";
-import { version } from "../package.json";
+import express = require("express");
+import swaggerJSDoc = require("swagger-jsdoc");
+import swaggerUi = require("swagger-ui-express");
+import packageJSON = require("../package.json");
+import path = require("path");
 
 const app = express();
 app.use(express.json());
+app.use(express.static(path.resolve(__dirname, "../", "public")));
 
 const swaggerSpec = swaggerJSDoc({
   swaggerDefinition: {
@@ -13,7 +15,7 @@ const swaggerSpec = swaggerJSDoc({
       title: "ColorMaster's API",
       description:
         "This API highlights the main functionality of ColorMaster. You can find out more information at [NPM - ColorMaster](https://www.npmjs.com/package/colormaster)",
-      version,
+      version: packageJSON.version,
       license: {
         name: "MIT License",
         url: "https://github.com/lbragile/ColorMaster/blob/master/LICENSE.md"
@@ -31,6 +33,11 @@ const swaggerSpec = swaggerJSDoc({
   apis: ["api/*"]
 });
 
-app.use("/api", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+const cssOpts = {
+  customCss: ".swagger-ui .topbar { display: none }",
+  customSiteTitle: "ColorMaster - A TypeScript library for all your coloring needs"
+};
+
+app.use("/api/v1", swaggerUi.serve, swaggerUi.setup(swaggerSpec, cssOpts));
 
 module.exports = app;

--- a/api/v1.ts
+++ b/api/v1.ts
@@ -28,7 +28,13 @@ const swaggerSpec = swaggerJSDoc({
     },
     tags: [{ name: "ColorMaster", description: "Routes for main functionality" }]
   },
-  apis: ["api/*"]
+  apis: [
+    "api/accessibility/contrast.ts",
+    "api/accessibility/statistics.ts",
+    "api/harmony.ts",
+    "api/manipulate.ts",
+    "api/mix.ts"
+  ]
 });
 
 const cssOpts = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
       "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "dev": true,
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -19,14 +18,12 @@
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -36,20 +33,17 @@
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-      "dev": true
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
     },
     "@apidevtools/swagger-methods": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-      "dev": true
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "@apidevtools/swagger-parser": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
       "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
-      "dev": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "@apidevtools/openapi-schemas": "^2.0.4",
@@ -1928,8 +1922,7 @@
     "@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "dev": true
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4141,8 +4134,7 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -10077,14 +10069,12 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -10099,8 +10089,7 @@
     "lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -14712,7 +14701,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.1.0.tgz",
       "integrity": "sha512-xgep5M8Gq31MxpCbQLvJZpNqHfGPfI+sILCzujZbEXIQp2COtkZgoGASs0gacRs4xHmLDH+GuMGdorPITSG4tA==",
-      "dev": true,
       "requires": {
         "commander": "6.2.0",
         "doctrine": "3.0.0",
@@ -14725,14 +14713,12 @@
         "commander": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
-          "dev": true
+          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
         },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -14745,8 +14731,7 @@
         "yaml": {
           "version": "2.0.0-1",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
-          "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
-          "dev": true
+          "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
         }
       }
     },
@@ -14754,7 +14739,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.2.tgz",
       "integrity": "sha512-9jHkHM+QXyLGFLk1DkXBwV+4HyNm0Za3b8/zk/+mjr8jgOSiqm3FOTHBSDsBjtn9scdL+8eWcHdupp2NLM8tDw==",
-      "dev": true,
       "requires": {
         "@apidevtools/swagger-parser": "10.0.2"
       }
@@ -14762,14 +14746,12 @@
     "swagger-ui-dist": {
       "version": "3.52.1",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.1.tgz",
-      "integrity": "sha512-S/UFHg1Zr5v5QUn7hCuoPqltuGrmobny66pZYdl/nb5p4OvFgEfYy9bY2ZaIZlgkX5kYkOdoEui8Hia0mtj74g==",
-      "dev": true
+      "integrity": "sha512-S/UFHg1Zr5v5QUn7hCuoPqltuGrmobny66pZYdl/nb5p4OvFgEfYy9bY2ZaIZlgkX5kYkOdoEui8Hia0mtj74g=="
     },
     "swagger-ui-express": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
       "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
-      "dev": true,
       "requires": {
         "swagger-ui-dist": "^3.18.1"
       }
@@ -15506,8 +15488,7 @@
     "validator": {
       "version": "13.6.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
-      "dev": true
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "value-equal": {
       "version": "1.0.1",
@@ -17003,7 +16984,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
       "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
-      "dev": true,
       "requires": {
         "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
@@ -17015,7 +16995,6 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,64 @@
 {
   "name": "demo",
-  "version": "0.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^4.2.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -1870,6 +1925,12 @@
         }
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2157,6 +2218,25 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -2170,6 +2250,29 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.4",
@@ -2240,6 +2343,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2275,6 +2384,18 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.15",
@@ -2331,6 +2452,16 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -2352,16 +2483,26 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/swagger-jsdoc": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.1.tgz",
+      "integrity": "sha512-+MUpcbyxD528dECUBCEVm6abNuORdbuGjbrUdHDeAQ+rkPuo2a+L4N02WJHF3bonSSE6SJ3dUJwF2V6+cHnf0w==",
+      "dev": true
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "@types/tapable": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ=="
-    },
-    "@types/tinycolor2": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
-      "integrity": "sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==",
-      "dev": true
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -3996,6 +4137,12 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -9927,6 +10074,18 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9936,6 +10095,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -14543,6 +14708,72 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swagger-jsdoc": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.1.0.tgz",
+      "integrity": "sha512-xgep5M8Gq31MxpCbQLvJZpNqHfGPfI+sILCzujZbEXIQp2COtkZgoGASs0gacRs4xHmLDH+GuMGdorPITSG4tA==",
+      "dev": true,
+      "requires": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "10.0.2",
+        "yaml": "2.0.0-1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "yaml": {
+          "version": "2.0.0-1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+          "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+          "dev": true
+        }
+      }
+    },
+    "swagger-parser": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-9jHkHM+QXyLGFLk1DkXBwV+4HyNm0Za3b8/zk/+mjr8jgOSiqm3FOTHBSDsBjtn9scdL+8eWcHdupp2NLM8tDw==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/swagger-parser": "10.0.2"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.52.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.1.tgz",
+      "integrity": "sha512-S/UFHg1Zr5v5QUn7hCuoPqltuGrmobny66pZYdl/nb5p4OvFgEfYy9bY2ZaIZlgkX5kYkOdoEui8Hia0mtj74g==",
+      "dev": true
+    },
+    "swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+      "dev": true,
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15272,6 +15503,12 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
+      "dev": true
+    },
     "value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -15550,12 +15787,6 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==",
-      "dev": true
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -16767,6 +16998,27 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "z-schema": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.6.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
     "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "^2.0.3"
+    "semantic-ui-react": "^2.0.3",
+    "swagger-jsdoc": "^6.1.0",
+    "swagger-ui-express": "^4.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.13.14",
@@ -33,8 +35,6 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "express": "^4.17.1",
     "styled-components": "^5.3.0",
-    "swagger-jsdoc": "^6.1.0",
-    "swagger-ui-express": "^4.1.6",
     "typescript": "^4.3.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "demo",
   "description": "💻 A playground for the ColorMaster module",
-  "version": "0.1.0",
+  "version": "1.2.1",
   "private": true,
   "dependencies": {
     "colormaster": "^1.2.1",
@@ -17,21 +17,25 @@
     "@babel/core": "^7.13.14",
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-react": "^7.13.13",
+    "@types/express": "^4.17.13",
     "@types/node": "^12.20.17",
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",
     "@types/styled-components": "^5.1.12",
-    "@types/tinycolor2": "^1.4.3",
+    "@types/swagger-jsdoc": "^6.0.1",
+    "@types/swagger-ui-express": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.29.3",
     "@vercel/node": "^1.12.1",
     "eslint": "^7.23.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "express": "^4.17.1",
     "styled-components": "^5.3.0",
-    "typescript": "^4.3.5",
-    "web-vitals": "^1.1.2"
+    "swagger-jsdoc": "^6.1.0",
+    "swagger-ui-express": "^4.1.6",
+    "typescript": "^4.3.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/rest.http
+++ b/rest.http
@@ -5,11 +5,15 @@
 # https://colormaster.vercel.app/api
 @baseUrl = http://localhost:3000/api
 
-# Contrast
+# Accessiblity/Contrast
 @fgColor = 000000ff
 @bgColor = 808080ff
 @showRatio = true
 @size = large
+
+# Accessiblity/Statistics
+@statsColor = dfaf20ff
+@statsAlpha = [true,true,true,true]
 
 # Harmony
 @color = ff0000ff
@@ -35,7 +39,12 @@
 ### REST ###
 
 ###
-GET {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}} HTTP/1.1
+GET {{baseUrl}}/accessibility/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}} HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+###
+GET {{baseUrl}}/accessibility/statistics?color={{statsColor}}&alpha={{statsAlpha}} HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -51,15 +60,23 @@ Content-Type: application/json
 Accept: application/json
 
 ###
-GET {{baseUrl}}/manipulation?color={{manipColor}}&isIncrement={{isIncrement}}&hueBy={{hueBy}}&satBy={{satBy}}&lightBy={{lightBy}}&alphaBy={{alphaBy}}&alpha={{alpha}} HTTP/1.1
+GET {{baseUrl}}/manipulate?color={{manipColor}}&isIncrement={{isIncrement}}&hueBy={{hueBy}}&satBy={{satBy}}&lightBy={{lightBy}}&alphaBy={{alphaBy}}&alpha={{alpha}} HTTP/1.1
 Content-Type: application/json
 Accept: application/json
+
+
 
 ### CURL ###
 
 ###
 curl -X 'GET'\
- {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}\
+ {{baseUrl}}/accessibility/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}\
+ -H Content-Type: application/json\
+ -H Accept: application/json
+
+###
+curl -X 'GET'\
+ {{baseUrl}}/accessibility/statistics?color={{statsColor}}&alpha={{statsAlpha}}\
  -H Content-Type: application/json\
  -H Accept: application/json
 
@@ -77,6 +94,6 @@ curl -X 'GET'\
 
 ###
 curl -X 'GET'\
- {{baseUrl}}/manipulation?color={{manipColor}}&isIncrement={{isIncrement}}&hueBy={{hueBy}}&satBy={{satBy}}&lightBy={{lightBy}}&alphaBy={{alphaBy}}&alpha={{alpha}}\
+ {{baseUrl}}/manipulate?color={{manipColor}}&isIncrement={{isIncrement}}&hueBy={{hueBy}}&satBy={{satBy}}&lightBy={{lightBy}}&alphaBy={{alphaBy}}&alpha={{alpha}}\
  -H Content-Type: application/json\
  -H Accept: application/json

--- a/rest.http
+++ b/rest.http
@@ -1,22 +1,9 @@
 # This file can be used, with VS Code's Rest Client Extension (https://marketplace.visualstudio.com/items?itemName=humao.rest-client), 
 # to quickly get responses from ColorMaster's API.
 
-@baseUrl = http://localhost:3000/api
 # http://localhost:3000/api
 # https://colormaster.vercel.app/api
-# https://colormaster-2pm8vjc79-lbragile.vercel.app/api
-
-# Mix
-@primary = 00ffffff
-@secondary = ff0000ff
-@ratio = 0.6
-@colorspace = luv
-
-# Harmony
-@color = ff0000ff
-@type = monochromatic
-@effect = shades
-@amount = 7
+@baseUrl = http://localhost:3000/api
 
 # Contrast
 @fgColor = 000000ff
@@ -24,8 +11,23 @@
 @showRatio = true
 @size = large
 
+# Harmony
+@color = ff0000ff
+@type = monochromatic
+@effect = shades
+@amount = 7
+
+# Mix
+@primary = 00ffffff
+@secondary = ff0000ff
+@ratio = 0.6
+@colorspace = luv
+
+
+### REST ###
+
 ###
-GET {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}
+GET {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}
 Content-Type: application/json
 Accept: application/json
 
@@ -34,13 +36,17 @@ GET {{baseUrl}}/harmony?color={{color}}&type={{type}}&effect={{effect}}&amount={
 Content-Type: application/json
 Accept: application/json
 
+
 ###
-GET {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}
+GET {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}
 Content-Type: application/json
 Accept: application/json
 
+
+### CURL ###
+
 ###
-curl {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}\
+curl {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}\
  -H Content-Type: application/json\
  -H Accept: application/json
 
@@ -50,6 +56,6 @@ curl {{baseUrl}}/harmony?color={{color}}&type={{type}}&effect={{effect}}&amount=
  -H Accept: application/json
 
 ###
-curl {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}\
+curl {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}\
  -H Content-Type: application/json\
  -H Accept: application/json

--- a/rest.http
+++ b/rest.http
@@ -23,39 +23,60 @@
 @ratio = 0.6
 @colorspace = luv
 
+# Manipulate
+@manipColor = ffff0080
+@hueBy = 72
+@satBy = 15
+@lightBy = 10
+@alphaBy = 0.05
+@isIncrement = true
+@alpha = [true,true,true,true]
 
 ### REST ###
 
 ###
-GET {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}
+GET {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}} HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
 ###
-GET {{baseUrl}}/harmony?color={{color}}&type={{type}}&effect={{effect}}&amount={{amount}}
+GET {{baseUrl}}/harmony?color={{color}}&type={{type}}&effect={{effect}}&amount={{amount}} HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
 
 ###
-GET {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}
+GET {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}} HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
+###
+GET {{baseUrl}}/manipulation?color={{manipColor}}&isIncrement={{isIncrement}}&hueBy={{hueBy}}&satBy={{satBy}}&lightBy={{lightBy}}&alphaBy={{alphaBy}}&alpha={{alpha}} HTTP/1.1
+Content-Type: application/json
+Accept: application/json
 
 ### CURL ###
 
 ###
-curl {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}\
+curl -X 'GET'\
+ {{baseUrl}}/contrast?fgColor={{fgColor}}&bgColor={{bgColor}}&ratio={{showRatio}}&size={{size}}\
  -H Content-Type: application/json\
  -H Accept: application/json
 
 ###
-curl {{baseUrl}}/harmony?color={{color}}&type={{type}}&effect={{effect}}&amount={{amount}}\
+curl -X 'GET'\
+ {{baseUrl}}/harmony?color={{color}}&type={{type}}&effect={{effect}}&amount={{amount}}\
  -H Content-Type: application/json\
  -H Accept: application/json
 
 ###
-curl {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}\
+curl -X 'GET'\
+ {{baseUrl}}/mix?primary={{primary}}&secondary={{secondary}}&ratio={{ratio}}&colorspace={{colorspace}}\
+ -H Content-Type: application/json\
+ -H Accept: application/json
+
+###
+curl -X 'GET'\
+ {{baseUrl}}/manipulation?color={{manipColor}}&isIncrement={{isIncrement}}&hueBy={{hueBy}}&satBy={{satBy}}&lightBy={{lightBy}}&alphaBy={{alphaBy}}&alpha={{alpha}}\
  -H Content-Type: application/json\
  -H Accept: application/json

--- a/src/components/Analysis/A11yStatisticsAnalysis.tsx
+++ b/src/components/Analysis/A11yStatisticsAnalysis.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useState } from "react";
+import { Grid, Header, Icon } from "semantic-ui-react";
+import ColorSelectorWidget from "../ColorSelectorWidget";
+import useDebounce from "../../hooks/useDebounce";
+import CM, { ColorMaster, extendPlugins } from "colormaster";
+import A11yPlugin from "colormaster/plugins/accessibility";
+import { useHistory } from "react-router";
+import useQuery from "../../hooks/useQuery";
+import Spacers from "../Spacers";
+import BreadcrumbPath from "../BreadcrumbPath";
+import { Swatch } from "../../styles/Swatch";
+import ColorIndicator from "../ColorIndicator";
+
+extendPlugins([A11yPlugin]);
+
+interface IPureHue {
+  pure: boolean;
+  reason: string;
+}
+
+export default function HarmonyAnalysis(): JSX.Element {
+  const history = useHistory();
+  const query = useQuery();
+
+  const [color, setColor] = useState(CM(query.color ?? "hsla(0, 75%, 50%, 1)"));
+  const [pureHue, setPureHue] = useState<IPureHue>(color.isPureHue() as IPureHue);
+  const [closest, setClosest] = useState<{ [K in "warm" | "cool" | "pure" | "web"]: ColorMaster }>({
+    warm: CM(color.hsla()).closestWarm(),
+    cool: CM(color.hsla()).closestCool(),
+    pure: CM(color.hsla()).closestPureHue(),
+    web: CM(color.hsla()).closestWebSafe()
+  });
+
+  const [alphaWarm, setAlphaWarm] = useState(true);
+  const [alphaCool, setAlphaCool] = useState(true);
+  const [alphaPure, setAlphaPure] = useState(true);
+  const [alphaWeb, setAlphaWeb] = useState(true);
+
+  const colorDebounce = useDebounce(color, 100);
+
+  useEffect(() => {
+    setPureHue(color.isPureHue() as IPureHue);
+    setClosest({
+      warm: CM(color.hsla()).closestWarm(),
+      cool: CM(color.hsla()).closestCool(),
+      pure: CM(color.hsla()).closestPureHue(),
+      web: CM(color.hsla()).closestWebSafe()
+    });
+  }, [color]);
+
+  useEffect(() => {
+    history.replace({
+      pathname: "/accessibility/statistics",
+      search: `?color=${colorDebounce.stringHEX().slice(1).toLowerCase()}`
+    });
+  }, [history, colorDebounce]);
+
+  return (
+    <>
+      <BreadcrumbPath path="Statistics" />
+
+      <Spacers height="40px" />
+
+      <Grid verticalAlign="middle" stackable>
+        <Grid.Row columns={3}>
+          <Grid.Column width={5}>
+            <ColorSelectorWidget
+              color={color}
+              setColor={setColor}
+              initPicker="wheel"
+              initColorspace="hsl"
+              harmony={[closest.warm, closest.cool, closest.pure, closest.web]}
+            />
+          </Grid.Column>
+
+          <Spacers width="24px" />
+
+          <Grid.Column width={3} textAlign="center">
+            <Header as="h2">
+              Brightness
+              <Spacers height="8px" />
+              <Header.Subheader>{color.brightness()}</Header.Subheader>
+            </Header>
+
+            <Header as="h2">
+              Luminance
+              <Spacers height="8px" />
+              <Header.Subheader>{color.luminance()}</Header.Subheader>
+            </Header>
+
+            <Header as="h2">
+              Light | Dark
+              <Spacers height="8px" />
+              <Header.Subheader>
+                {color.isLight() ? "Light" : "Dark"} <Spacers width="2px" />
+                <Icon name="sun" color={color.isLight() ? "yellow" : "black"} />
+              </Header.Subheader>
+            </Header>
+
+            <Header as="h2">
+              Warm | Cool
+              <Spacers height="8px" />
+              <Header.Subheader>
+                {color.isWarm() ? "Warm" : "Cool"} <Spacers width="2px" />
+                <Icon name={color.isWarm() ? "fire" : "snowflake"} color={color.isWarm() ? "red" : "blue"} />
+              </Header.Subheader>
+            </Header>
+
+            <Header as="h2">
+              Tinted | Shaded | Toned
+              <Spacers height="8px" />
+              <Header.Subheader>
+                {pureHue.reason !== "N/A" ? pureHue.reason[0].toUpperCase() + pureHue.reason.slice(1) : "N/A"}
+              </Header.Subheader>
+            </Header>
+
+            <Header as="h2">
+              Pure Hue?
+              <Spacers height="8px" />
+              <Header.Subheader>
+                <Icon name={pureHue.pure ? "check" : "x"} color={pureHue.pure ? "green" : "red"} />
+              </Header.Subheader>
+            </Header>
+          </Grid.Column>
+
+          <Spacers width="24px" />
+
+          <Grid.Column width={6}>
+            <Grid columns="equal" verticalAlign="middle" textAlign="center">
+              <Grid.Row>
+                <Grid.Column width={8}>
+                  <Header>Closest Warm</Header>
+
+                  <ColorIndicator
+                    color={closest.warm.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaWarm })}
+                    alpha={alphaWarm}
+                    setAlpha={setAlphaWarm}
+                  />
+
+                  <Spacers height="8px" />
+
+                  <Swatch
+                    title={closest.warm.stringHSL({ precision: [2, 2, 2, 2] })}
+                    $radius={75}
+                    $borderRadius="4px"
+                    background={closest.warm.stringHSL()}
+                    onClick={() => setColor(closest.warm)}
+                    $cursor="pointer"
+                  />
+                </Grid.Column>
+
+                <Grid.Column width={8}>
+                  <Header>Closest Cool</Header>
+
+                  <ColorIndicator
+                    color={closest.cool.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaCool })}
+                    alpha={alphaCool}
+                    setAlpha={setAlphaCool}
+                  />
+
+                  <Spacers height="8px" />
+
+                  <Swatch
+                    title={closest.cool.stringHSL({ precision: [2, 2, 2, 2] })}
+                    $radius={75}
+                    $borderRadius="4px"
+                    background={closest.cool.stringHSL()}
+                    onClick={() => setColor(closest.cool)}
+                    $cursor="pointer"
+                  />
+                </Grid.Column>
+              </Grid.Row>
+
+              <Grid.Row>
+                <Grid.Column width={8}>
+                  <Header>Closest Pure Hue</Header>
+
+                  <ColorIndicator
+                    color={closest.pure.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaPure })}
+                    alpha={alphaPure}
+                    setAlpha={setAlphaPure}
+                  />
+
+                  <Spacers height="8px" />
+
+                  <Swatch
+                    title={closest.pure.stringHSL({ precision: [2, 2, 2, 2] })}
+                    $radius={75}
+                    $borderRadius="4px"
+                    background={closest.pure.stringHSL()}
+                    onClick={() => setColor(closest.pure)}
+                    $cursor="pointer"
+                  />
+                </Grid.Column>
+
+                <Grid.Column width={8}>
+                  <Header>Closest Web Safe</Header>
+
+                  <ColorIndicator
+                    color={closest.web.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaWeb })}
+                    alpha={alphaWeb}
+                    setAlpha={setAlphaWeb}
+                  />
+
+                  <Spacers height="8px" />
+
+                  <Swatch
+                    title={closest.web.stringHSL({ precision: [2, 2, 2, 2] })}
+                    $radius={75}
+                    $borderRadius="4px"
+                    background={closest.web.stringHSL()}
+                    onClick={() => setColor(closest.web)}
+                    $cursor="pointer"
+                  />
+                </Grid.Column>
+              </Grid.Row>
+            </Grid>
+
+            <Spacers height="32px" />
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    </>
+  );
+}

--- a/src/components/Analysis/ContrastAnalysis.tsx
+++ b/src/components/Analysis/ContrastAnalysis.tsx
@@ -83,10 +83,10 @@ export default function ContrastAnalysis(): JSX.Element {
             <Header.Subheader>
               <Grid centered>
                 <Grid.Row columns={2}>
-                  <Grid.Column width={4} textAlign="center">
+                  <Grid.Column width={8} textAlign="right">
                     <Radio label="Body" name="radioGroup" checked={!isLarge} onChange={() => setIsLarge(!isLarge)} />
                   </Grid.Column>
-                  <Grid.Column width={4} textAlign="center">
+                  <Grid.Column width={8} textAlign="left">
                     <Radio label="Large" name="radioGroup" checked={isLarge} onChange={() => setIsLarge(!isLarge)} />
                   </Grid.Column>
 

--- a/src/components/Analysis/ContrastAnalysis.tsx
+++ b/src/components/Analysis/ContrastAnalysis.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Checkbox, Divider, Grid, Header, Icon, Label, Radio, Table } from "semantic-ui-react";
+import { Checkbox, Grid, Header, Icon, Label, Radio, Table } from "semantic-ui-react";
 import ColorSelectorWidget from "../ColorSelectorWidget";
 import CM, { extendPlugins } from "colormaster";
 import A11yPlugin from "colormaster/plugins/accessibility";
@@ -10,6 +10,7 @@ import { ContrastSample } from "../../utils/codeSamples";
 import CodeModal from "./CodeModal";
 import { useHistory } from "react-router";
 import useQuery from "../../hooks/useQuery";
+import Spacers from "../Spacers";
 
 extendPlugins([A11yPlugin]);
 
@@ -23,6 +24,7 @@ const SampleOutput = styled.div.attrs((props: { background: string; color: strin
   border: 1px solid hsla(0, 0%, 90%, 1);
   text-align: left;
   line-height: 2rem;
+  margin-top: 12px;
 `;
 
 export default function ContrastAnalysis(): JSX.Element {
@@ -69,38 +71,42 @@ export default function ContrastAnalysis(): JSX.Element {
         <Grid.Column width={5}>
           <ColorSelectorWidget color={fgColor} setColor={setFgColor}>
             <Label size="big" color="black" attached="top left">
-              {isMobile ? "FG" : "Foreground (FG)"}
+              {isMobile ? "FG" : "Foreground"}
             </Label>
           </ColorSelectorWidget>
         </Grid.Column>
 
         <Grid.Column width={6} textAlign="center">
-          <Header as="h2">Sample Output</Header>
-          <Grid centered>
-            <Grid.Row columns={2}>
-              <Grid.Column width={4} textAlign="center">
-                <Radio label="Body" name="radioGroup" checked={!isLarge} onChange={() => setIsLarge(!isLarge)} />
-              </Grid.Column>
-              <Grid.Column width={4} textAlign="center">
-                <Radio label="Large" name="radioGroup" checked={isLarge} onChange={() => setIsLarge(!isLarge)} />
-              </Grid.Column>
-            </Grid.Row>
+          <Header as="h2">
+            Sample Output
+            <Spacers height="16px" />
+            <Header.Subheader>
+              <Grid centered>
+                <Grid.Row columns={2}>
+                  <Grid.Column width={4} textAlign="center">
+                    <Radio label="Body" name="radioGroup" checked={!isLarge} onChange={() => setIsLarge(!isLarge)} />
+                  </Grid.Column>
+                  <Grid.Column width={4} textAlign="center">
+                    <Radio label="Large" name="radioGroup" checked={isLarge} onChange={() => setIsLarge(!isLarge)} />
+                  </Grid.Column>
 
-            <Grid.Row>
-              <SampleOutput
-                background={bgDebounce.stringRGB()}
-                color={fgDebounce.stringRGB()}
-                size={isLarge ? "large" : "body"}
-              >
-                The quick brown fox jumps over the lazy dog.
-              </SampleOutput>
-            </Grid.Row>
-          </Grid>
+                  <SampleOutput
+                    background={bgDebounce.stringRGB()}
+                    color={fgDebounce.stringRGB()}
+                    size={isLarge ? "large" : "body"}
+                  >
+                    The quick brown fox jumps over the lazy dog.
+                  </SampleOutput>
+                </Grid.Row>
+              </Grid>
+            </Header.Subheader>
+          </Header>
 
-          <Divider hidden />
+          <Spacers height="8px" />
 
           <Header as="h2" textAlign="center">
             Contrast
+            <Spacers height="8px" />
             <Header.Subheader>
               <Grid textAlign="center">
                 <Grid.Row>
@@ -117,46 +123,49 @@ export default function ContrastAnalysis(): JSX.Element {
             </Header.Subheader>
           </Header>
 
-          <Divider hidden />
+          <Spacers height="8px" />
 
           <Header as="h2" textAlign="center">
             ReadableOn
+            <Spacers height="8px" />
+            <Header.Subheader>
+              <Table definition celled textAlign="center">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell></Table.HeaderCell>
+                    <Table.HeaderCell>Minimum (AA)</Table.HeaderCell>
+                    <Table.HeaderCell>Enhanced (AAA)</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+
+                <Table.Body>
+                  <Table.Row>
+                    <Table.Cell>Body</Table.Cell>
+                    <Table.Cell positive={readableOn[0]} negative={!readableOn[0]}>
+                      <Icon name={readableOn[0] ? "checkmark" : "x"} /> 4.5:1
+                    </Table.Cell>
+                    <Table.Cell positive={readableOn[1]} negative={!readableOn[1]}>
+                      <Icon name={readableOn[1] ? "checkmark" : "x"} />
+                      7.0:1
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.Cell>Large</Table.Cell>
+                    <Table.Cell positive={readableOn[2]} negative={!readableOn[2]}>
+                      <Icon name={readableOn[2] ? "checkmark" : "x"} />
+                      3.0:1
+                    </Table.Cell>
+
+                    <Table.Cell positive={readableOn[3]} negative={!readableOn[3]}>
+                      <Icon name={readableOn[3] ? "checkmark" : "x"} /> 4.5:1
+                    </Table.Cell>
+                  </Table.Row>
+                </Table.Body>
+              </Table>
+            </Header.Subheader>
           </Header>
-          <Table definition celled textAlign="center">
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell></Table.HeaderCell>
-                <Table.HeaderCell>Minimum (AA)</Table.HeaderCell>
-                <Table.HeaderCell>Enhanced (AAA)</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
 
-            <Table.Body>
-              <Table.Row>
-                <Table.Cell>Body</Table.Cell>
-                <Table.Cell positive={readableOn[0]} negative={!readableOn[0]}>
-                  <Icon name={readableOn[0] ? "checkmark" : "x"} /> 4.5:1
-                </Table.Cell>
-                <Table.Cell positive={readableOn[1]} negative={!readableOn[1]}>
-                  <Icon name={readableOn[1] ? "checkmark" : "x"} />
-                  7.0:1
-                </Table.Cell>
-              </Table.Row>
-              <Table.Row>
-                <Table.Cell>Large</Table.Cell>
-                <Table.Cell positive={readableOn[2]} negative={!readableOn[2]}>
-                  <Icon name={readableOn[2] ? "checkmark" : "x"} />
-                  3.0:1
-                </Table.Cell>
-
-                <Table.Cell positive={readableOn[3]} negative={!readableOn[3]}>
-                  <Icon name={readableOn[3] ? "checkmark" : "x"} /> 4.5:1
-                </Table.Cell>
-              </Table.Row>
-            </Table.Body>
-          </Table>
-
-          <Divider hidden />
+          <Spacers height="12px" />
 
           <CodeModal code={ContrastSample(fgDebounce, bgDebounce, contrastDebounce, readableOnDebounce, ratio)} />
         </Grid.Column>
@@ -164,7 +173,7 @@ export default function ContrastAnalysis(): JSX.Element {
         <Grid.Column width={5}>
           <ColorSelectorWidget color={bgColor} setColor={setBgColor} initPicker="sketch">
             <Label size="big" color="black" attached="top right">
-              {isMobile ? "BG" : "Background (BG)"}
+              {isMobile ? "BG" : "Background"}
             </Label>
           </ColorSelectorWidget>
         </Grid.Column>

--- a/src/components/Analysis/ContrastAnalysis.tsx
+++ b/src/components/Analysis/ContrastAnalysis.tsx
@@ -31,6 +31,7 @@ const SampleOutput = styled.div.attrs((props: { background: string; color: strin
 export default function ContrastAnalysis(): JSX.Element {
   const history = useHistory();
   const query = useQuery();
+  const { isMobile } = useBreakpointMap();
 
   const [fgColor, setFgColor] = useState(CM(query.fgColor ?? "hsla(60, 100%, 50%, 1)"));
   const [bgColor, setBgColor] = useState(CM(query.bgColor ?? "hsla(240, 100%, 50%, 1)"));
@@ -43,8 +44,6 @@ export default function ContrastAnalysis(): JSX.Element {
   const bgDebounce = useDebounce(bgColor, 100);
   const contrastDebounce = useDebounce(contrast, 100);
   const readableOnDebounce = useDebounce(readableOn, 100);
-
-  const { isMobile } = useBreakpointMap();
 
   useEffect(() => {
     setContrast(fgColor.contrast({ bgColor: bgColor, ratio, precision: 3 }));
@@ -68,9 +67,11 @@ export default function ContrastAnalysis(): JSX.Element {
 
   return (
     <>
+      {isMobile && <Spacers height="24px" />}
+
       <BreadcrumbPath path="Contrast" />
 
-      <Spacers height="20px" />
+      <Spacers height={isMobile ? "40px" : "20px"} />
 
       <Grid columns={3} verticalAlign="middle" stackable centered>
         <Grid.Row>

--- a/src/components/Analysis/ContrastAnalysis.tsx
+++ b/src/components/Analysis/ContrastAnalysis.tsx
@@ -11,6 +11,7 @@ import CodeModal from "./CodeModal";
 import { useHistory } from "react-router";
 import useQuery from "../../hooks/useQuery";
 import Spacers from "../Spacers";
+import BreadcrumbPath from "../BreadcrumbPath";
 
 extendPlugins([A11yPlugin]);
 
@@ -57,7 +58,7 @@ export default function ContrastAnalysis(): JSX.Element {
 
   useEffect(() => {
     history.replace({
-      pathname: "/contrast",
+      pathname: "/accessibility/contrast",
       search: `?fgColor=${fgDebounce.stringHEX().slice(1).toLowerCase()}&bgColor=${bgDebounce
         .stringHEX()
         .slice(1)
@@ -66,118 +67,124 @@ export default function ContrastAnalysis(): JSX.Element {
   }, [history, fgDebounce, bgDebounce, ratio, isLarge]);
 
   return (
-    <Grid columns={3} verticalAlign="middle" stackable centered>
-      <Grid.Row>
-        <Grid.Column width={5}>
-          <ColorSelectorWidget color={fgColor} setColor={setFgColor}>
-            <Label size="big" color="black" attached="top left">
-              {isMobile ? "FG" : "Foreground"}
-            </Label>
-          </ColorSelectorWidget>
-        </Grid.Column>
+    <>
+      <BreadcrumbPath path="Contrast" />
 
-        <Grid.Column width={6} textAlign="center">
-          <Header as="h2">
-            Sample Output
-            <Spacers height="16px" />
-            <Header.Subheader>
-              <Grid centered>
-                <Grid.Row columns={2}>
-                  <Grid.Column width={8} textAlign="right">
-                    <Radio label="Body" name="radioGroup" checked={!isLarge} onChange={() => setIsLarge(!isLarge)} />
-                  </Grid.Column>
-                  <Grid.Column width={8} textAlign="left">
-                    <Radio label="Large" name="radioGroup" checked={isLarge} onChange={() => setIsLarge(!isLarge)} />
-                  </Grid.Column>
+      <Spacers height="20px" />
 
-                  <SampleOutput
-                    background={bgDebounce.stringRGB()}
-                    color={fgDebounce.stringRGB()}
-                    size={isLarge ? "large" : "body"}
-                  >
-                    The quick brown fox jumps over the lazy dog.
-                  </SampleOutput>
-                </Grid.Row>
-              </Grid>
-            </Header.Subheader>
-          </Header>
+      <Grid columns={3} verticalAlign="middle" stackable centered>
+        <Grid.Row>
+          <Grid.Column width={5}>
+            <ColorSelectorWidget color={fgColor} setColor={setFgColor}>
+              <Label size="big" color="black" attached="top left">
+                {isMobile ? "FG" : "Foreground"}
+              </Label>
+            </ColorSelectorWidget>
+          </Grid.Column>
 
-          <Spacers height="8px" />
+          <Grid.Column width={6} textAlign="center">
+            <Header as="h2">
+              Sample Output
+              <Spacers height="16px" />
+              <Header.Subheader>
+                <Grid centered>
+                  <Grid.Row columns={2}>
+                    <Grid.Column width={8} textAlign="right">
+                      <Radio label="Body" name="radioGroup" checked={!isLarge} onChange={() => setIsLarge(!isLarge)} />
+                    </Grid.Column>
+                    <Grid.Column width={8} textAlign="left">
+                      <Radio label="Large" name="radioGroup" checked={isLarge} onChange={() => setIsLarge(!isLarge)} />
+                    </Grid.Column>
 
-          <Header as="h2" textAlign="center">
-            Contrast
+                    <SampleOutput
+                      background={bgDebounce.stringRGB()}
+                      color={fgDebounce.stringRGB()}
+                      size={isLarge ? "large" : "body"}
+                    >
+                      The quick brown fox jumps over the lazy dog.
+                    </SampleOutput>
+                  </Grid.Row>
+                </Grid>
+              </Header.Subheader>
+            </Header>
+
             <Spacers height="8px" />
-            <Header.Subheader>
-              <Grid textAlign="center">
-                <Grid.Row>
-                  <Grid.Column width={1} />
-                  <Grid.Column textAlign="right">
-                    <b>{contrast}</b>
-                  </Grid.Column>
-                  <Grid.Column width={1} />
-                  <Grid.Column width={1} textAlign="left">
-                    <Checkbox label="Ratio" checked={ratio} onChange={() => setRatio(!ratio)} />
-                  </Grid.Column>
-                </Grid.Row>
-              </Grid>
-            </Header.Subheader>
-          </Header>
 
-          <Spacers height="8px" />
+            <Header as="h2" textAlign="center">
+              Contrast
+              <Spacers height="8px" />
+              <Header.Subheader>
+                <Grid textAlign="center">
+                  <Grid.Row>
+                    <Grid.Column width={1} />
+                    <Grid.Column textAlign="right">
+                      <b>{contrast}</b>
+                    </Grid.Column>
+                    <Grid.Column width={1} />
+                    <Grid.Column width={1} textAlign="left">
+                      <Checkbox label="Ratio" checked={ratio} onChange={() => setRatio(!ratio)} />
+                    </Grid.Column>
+                  </Grid.Row>
+                </Grid>
+              </Header.Subheader>
+            </Header>
 
-          <Header as="h2" textAlign="center">
-            ReadableOn
             <Spacers height="8px" />
-            <Header.Subheader>
-              <Table definition celled textAlign="center">
-                <Table.Header>
-                  <Table.Row>
-                    <Table.HeaderCell></Table.HeaderCell>
-                    <Table.HeaderCell>Minimum (AA)</Table.HeaderCell>
-                    <Table.HeaderCell>Enhanced (AAA)</Table.HeaderCell>
-                  </Table.Row>
-                </Table.Header>
 
-                <Table.Body>
-                  <Table.Row>
-                    <Table.Cell>Body</Table.Cell>
-                    <Table.Cell positive={readableOn[0]} negative={!readableOn[0]}>
-                      <Icon name={readableOn[0] ? "checkmark" : "x"} /> 4.5:1
-                    </Table.Cell>
-                    <Table.Cell positive={readableOn[1]} negative={!readableOn[1]}>
-                      <Icon name={readableOn[1] ? "checkmark" : "x"} />
-                      7.0:1
-                    </Table.Cell>
-                  </Table.Row>
-                  <Table.Row>
-                    <Table.Cell>Large</Table.Cell>
-                    <Table.Cell positive={readableOn[2]} negative={!readableOn[2]}>
-                      <Icon name={readableOn[2] ? "checkmark" : "x"} />
-                      3.0:1
-                    </Table.Cell>
+            <Header as="h2" textAlign="center">
+              ReadableOn
+              <Spacers height="8px" />
+              <Header.Subheader>
+                <Table definition celled textAlign="center">
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.HeaderCell></Table.HeaderCell>
+                      <Table.HeaderCell>Minimum (AA)</Table.HeaderCell>
+                      <Table.HeaderCell>Enhanced (AAA)</Table.HeaderCell>
+                    </Table.Row>
+                  </Table.Header>
 
-                    <Table.Cell positive={readableOn[3]} negative={!readableOn[3]}>
-                      <Icon name={readableOn[3] ? "checkmark" : "x"} /> 4.5:1
-                    </Table.Cell>
-                  </Table.Row>
-                </Table.Body>
-              </Table>
-            </Header.Subheader>
-          </Header>
+                  <Table.Body>
+                    <Table.Row>
+                      <Table.Cell>Body</Table.Cell>
+                      <Table.Cell positive={readableOn[0]} negative={!readableOn[0]}>
+                        <Icon name={readableOn[0] ? "checkmark" : "x"} /> 4.5:1
+                      </Table.Cell>
+                      <Table.Cell positive={readableOn[1]} negative={!readableOn[1]}>
+                        <Icon name={readableOn[1] ? "checkmark" : "x"} />
+                        7.0:1
+                      </Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>Large</Table.Cell>
+                      <Table.Cell positive={readableOn[2]} negative={!readableOn[2]}>
+                        <Icon name={readableOn[2] ? "checkmark" : "x"} />
+                        3.0:1
+                      </Table.Cell>
 
-          <Spacers height="12px" />
+                      <Table.Cell positive={readableOn[3]} negative={!readableOn[3]}>
+                        <Icon name={readableOn[3] ? "checkmark" : "x"} /> 4.5:1
+                      </Table.Cell>
+                    </Table.Row>
+                  </Table.Body>
+                </Table>
+              </Header.Subheader>
+            </Header>
 
-          <CodeModal code={ContrastSample(fgDebounce, bgDebounce, contrastDebounce, readableOnDebounce, ratio)} />
-        </Grid.Column>
+            <Spacers height="12px" />
 
-        <Grid.Column width={5}>
-          <ColorSelectorWidget color={bgColor} setColor={setBgColor} initPicker="sketch">
-            <Label size="big" color="black" attached="top right">
-              {isMobile ? "BG" : "Background"}
-            </Label>
-          </ColorSelectorWidget>
-        </Grid.Column>
-      </Grid.Row>
-    </Grid>
+            <CodeModal code={ContrastSample(fgDebounce, bgDebounce, contrastDebounce, readableOnDebounce, ratio)} />
+          </Grid.Column>
+
+          <Grid.Column width={5}>
+            <ColorSelectorWidget color={bgColor} setColor={setBgColor} initPicker="sketch">
+              <Label size="big" color="black" attached="top right">
+                {isMobile ? "BG" : "Background"}
+              </Label>
+            </ColorSelectorWidget>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    </>
   );
 }

--- a/src/components/Analysis/ContrastAnalysis.tsx
+++ b/src/components/Analysis/ContrastAnalysis.tsx
@@ -30,7 +30,7 @@ export default function ContrastAnalysis(): JSX.Element {
   const query = useQuery();
 
   const [fgColor, setFgColor] = useState(CM(query.fgColor ?? "hsla(60, 100%, 50%, 1)"));
-  const [bgColor, setBgColor] = useState(CM(query.bgColor ?? "hsla(0, 0%, 50%, 1)"));
+  const [bgColor, setBgColor] = useState(CM(query.bgColor ?? "hsla(240, 100%, 50%, 1)"));
   const [contrast, setContrast] = useState<number | string>("1:1");
   const [readableOn, setReadableOn] = useState(new Array(4).fill(false));
   const [isLarge, setIsLarge] = useState(query.size ? query.size === "large" : true);
@@ -162,7 +162,7 @@ export default function ContrastAnalysis(): JSX.Element {
         </Grid.Column>
 
         <Grid.Column width={5}>
-          <ColorSelectorWidget color={bgColor} setColor={setBgColor}>
+          <ColorSelectorWidget color={bgColor} setColor={setBgColor} initPicker="sketch">
             <Label size="big" color="black" attached="top right">
               {isMobile ? "BG" : "Background (BG)"}
             </Label>

--- a/src/components/Analysis/HarmonyAnalysis.tsx
+++ b/src/components/Analysis/HarmonyAnalysis.tsx
@@ -186,15 +186,15 @@ export default function HarmonyAnalysis(): JSX.Element {
             {[...harmony, ...new Array(11 - harmony.length).fill("transparent")].map((swatch, i) => (
               <Swatch
                 key={swatch + "_" + i}
-                title={swatch}
+                title={swatch === "transparent" ? undefined : swatch}
                 $radius={65}
                 $borderRadius="4px"
                 $borderColor={swatch === "transparent" ? swatch : undefined}
                 display="inline-block"
                 position="relative"
                 background={swatch}
-                onClick={() => setColor(CM(swatch))}
-                $clickable
+                onClick={() => swatch !== "transparent" && setColor(CM(swatch))}
+                $clickable={swatch !== "transparent"}
               >
                 {swatch !== "transparent" && <SwatchCounter>{i + 1}</SwatchCounter>}
                 {CM(swatch).stringHSL({ precision: [2, 2, 2, 2] }) === color.stringHSL({ precision: [2, 2, 2, 2] }) && (

--- a/src/components/Analysis/HarmonyAnalysis.tsx
+++ b/src/components/Analysis/HarmonyAnalysis.tsx
@@ -51,7 +51,7 @@ export default function HarmonyAnalysis(): JSX.Element {
   const history = useHistory();
   const query = useQuery();
 
-  const [color, setColor] = useState(CM(query.color ?? "hsla(0, 100%, 50%, 1)"));
+  const [color, setColor] = useState(CM(query.color ?? "hsla(0, 75%, 50%, 1)"));
   const [harmony, setHarmony] = useState(color.harmony().map((c) => c.stringHSL({ precision: [2, 2, 2, 2] })));
   const [type, setType] = useState<THarmony>(
     (typeOptions.find((item) => item.value === query.type)?.value as THarmony) ?? "analogous"
@@ -88,7 +88,8 @@ export default function HarmonyAnalysis(): JSX.Element {
           <ColorSelectorWidget
             color={color}
             setColor={setColor}
-            initPicker={3}
+            initPicker="wheel"
+            initColorspace="hsl"
             harmony={
               // only show harmonies if not shades or tints
               type !== "monochromatic" || (type === "monochromatic" && effect === "tones")

--- a/src/components/Analysis/HarmonyAnalysis.tsx
+++ b/src/components/Analysis/HarmonyAnalysis.tsx
@@ -196,7 +196,7 @@ export default function HarmonyAnalysis(): JSX.Element {
                 onClick={() => setColor(CM(swatch))}
                 $clickable
               >
-                {type === "monochromatic" && swatch !== "transparent" && <SwatchCounter>{i + 1}</SwatchCounter>}
+                {swatch !== "transparent" && <SwatchCounter>{i + 1}</SwatchCounter>}
                 {CM(swatch).stringHSL({ precision: [2, 2, 2, 2] }) === color.stringHSL({ precision: [2, 2, 2, 2] }) && (
                   <CurrentColorIcon name="check circle" inverted={color.isDark()} size="large" />
                 )}

--- a/src/components/Analysis/HarmonyAnalysis.tsx
+++ b/src/components/Analysis/HarmonyAnalysis.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Divider, Grid, Icon, Label, Menu } from "semantic-ui-react";
+import { Container, Grid, Icon, Label, Menu } from "semantic-ui-react";
 import ColorSelectorWidget from "../ColorSelectorWidget";
 import useDebounce from "../../hooks/useDebounce";
 import { Swatch } from "../../styles/Swatch";
@@ -13,6 +13,7 @@ import CodeModal from "./CodeModal";
 import A11yPlugin from "colormaster/plugins/accessibility";
 import { useHistory } from "react-router";
 import useQuery from "../../hooks/useQuery";
+import Spacers from "../Spacers";
 
 extendPlugins([HarmonyPlugin, A11yPlugin]);
 
@@ -44,6 +45,23 @@ const SwatchCounter = styled(Label)`
     color: black;
     position: absolute;
     left: 0;
+    top: -1px;
+  }
+`;
+
+const StyledMenu = styled(Menu)`
+  && {
+    margin: 0 auto;
+    margin-bottom: 24px;
+  }
+`;
+
+const MonoEffectList = styled.li`
+  list-style: none;
+  &:before {
+    content: "•";
+    margin-right: 4px;
+    font-size: smaller;
   }
 `;
 
@@ -82,7 +100,7 @@ export default function HarmonyAnalysis(): JSX.Element {
   }, [history, colorDebounce, type, effect, amount]);
 
   return (
-    <Grid columns={3} verticalAlign="middle" stackable centered>
+    <Grid verticalAlign="middle" stackable>
       <Grid.Row>
         <Grid.Column width={5}>
           <ColorSelectorWidget
@@ -100,7 +118,7 @@ export default function HarmonyAnalysis(): JSX.Element {
         </Grid.Column>
 
         <Grid.Column width={3} textAlign="left">
-          <Menu vertical>
+          <StyledMenu vertical>
             {typeOptions.map((t) => {
               return (
                 <Menu.Item
@@ -110,7 +128,7 @@ export default function HarmonyAnalysis(): JSX.Element {
                   onClick={() => setType(t.value as THarmony)}
                 >
                   {t.text}{" "}
-                  {t.text === "monochromatic" && (
+                  {t.text === "monochromatic" && type !== t.value && (
                     <Label color="teal">
                       <Icon name="chevron circle down" />
                       {effectOptions.length}
@@ -129,12 +147,13 @@ export default function HarmonyAnalysis(): JSX.Element {
                               setType("monochromatic");
                             }}
                           >
-                            {e.text}
+                            <MonoEffectList>{e.text}</MonoEffectList>
                           </Menu.Item>
                         );
                       })}
 
-                      <Divider hidden />
+                      <Spacers height="16px" />
+
                       <Menu.Item>
                         <Label attached="top left" color="teal">
                           Amount
@@ -155,35 +174,35 @@ export default function HarmonyAnalysis(): JSX.Element {
                 </Menu.Item>
               );
             })}
-          </Menu>
+          </StyledMenu>
 
-          <Divider hidden />
+          <Container textAlign="center">
+            <CodeModal code={HarmonySample(color, type, effect, amount)} />
+          </Container>
         </Grid.Column>
 
-        <Grid.Column columns="equal" textAlign="center">
+        <Grid.Column width={type === "monochromatic" ? 6 : 7} textAlign="center">
           <Grid.Row>
-            {harmony.map((swatch, i) => (
+            {[...harmony, ...new Array(11 - harmony.length).fill("transparent")].map((swatch, i) => (
               <Swatch
-                key={swatch}
+                key={swatch + "_" + i}
                 title={swatch}
-                radius={65}
-                borderRadius="4px"
+                $radius={65}
+                $borderRadius="4px"
+                $borderColor={swatch === "transparent" ? swatch : undefined}
                 display="inline-block"
                 position="relative"
                 background={swatch}
                 onClick={() => setColor(CM(swatch))}
                 $clickable
               >
-                {type === "monochromatic" && <SwatchCounter>{i + 1}</SwatchCounter>}
+                {type === "monochromatic" && swatch !== "transparent" && <SwatchCounter>{i + 1}</SwatchCounter>}
                 {CM(swatch).stringHSL({ precision: [2, 2, 2, 2] }) === color.stringHSL({ precision: [2, 2, 2, 2] }) && (
                   <CurrentColorIcon name="check circle" inverted={color.isDark()} size="large" />
                 )}
               </Swatch>
             ))}
           </Grid.Row>
-
-          <Divider hidden />
-          <CodeModal code={HarmonySample(color, type, effect, amount)} />
         </Grid.Column>
       </Grid.Row>
     </Grid>

--- a/src/components/Analysis/HarmonyAnalysis.tsx
+++ b/src/components/Analysis/HarmonyAnalysis.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Container, Grid, Icon, Label, Menu } from "semantic-ui-react";
 import ColorSelectorWidget from "../ColorSelectorWidget";
 import useDebounce from "../../hooks/useDebounce";
-import { Swatch } from "../../styles/Swatch";
+import { CurrentColorIcon, Swatch, SwatchCounter } from "../../styles/Swatch";
 import RangeSlider from "../Sliders/RangeSlider";
 import { HarmonySample } from "../../utils/codeSamples";
 import CM, { extendPlugins } from "colormaster";
@@ -29,25 +29,6 @@ const typeOptions = [
 ].map((value) => ({ key: value, text: value.includes("double") ? "double split-complementary" : value, value }));
 
 const effectOptions = ["shades", "tints", "tones"].map((value) => ({ key: value, text: value, value }));
-
-const CurrentColorIcon = styled(Icon)`
-  && {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
-`;
-
-const SwatchCounter = styled(Label)`
-  && {
-    border-radius: 2px 0;
-    color: black;
-    position: absolute;
-    left: 0;
-    top: -1px;
-  }
-`;
 
 const StyledMenu = styled(Menu)`
   && {

--- a/src/components/Analysis/HarmonyAnalysis.tsx
+++ b/src/components/Analysis/HarmonyAnalysis.tsx
@@ -194,7 +194,7 @@ export default function HarmonyAnalysis(): JSX.Element {
                 position="relative"
                 background={swatch}
                 onClick={() => swatch !== "transparent" && setColor(CM(swatch))}
-                $clickable={swatch !== "transparent"}
+                $cursor={swatch !== "transparent" ? "pointer" : ""}
               >
                 {swatch !== "transparent" && <SwatchCounter>{i + 1}</SwatchCounter>}
                 {CM(swatch).stringHSL({ precision: [2, 2, 2, 2] }) === color.stringHSL({ precision: [2, 2, 2, 2] }) && (

--- a/src/components/Analysis/ManipulateAnalysis.tsx
+++ b/src/components/Analysis/ManipulateAnalysis.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { Container, Divider, Dropdown, Grid, Header, Icon, Label, List, Popup } from "semantic-ui-react";
+import { Container, Divider, Dropdown, Grid, Header, Icon, List, Popup } from "semantic-ui-react";
 import ColorSelectorWidget from "../ColorSelectorWidget";
 import useDebounce from "../../hooks/useDebounce";
-import { Swatch } from "../../styles/Swatch";
+import { Swatch, SwatchCounter } from "../../styles/Swatch";
 import { useHistory } from "react-router";
 import useQuery from "../../hooks/useQuery";
 import useSliderChange from "../../hooks/useSliderChange";
@@ -36,33 +36,28 @@ const ColorAdjustmentOpts = [
   }
 ];
 
-const Information = ({ index, text }: { index: number; text: string }) => {
+const Information = ({ text }: { text: string }) => {
   return (
     <Popup
       trigger={<Icon name="info circle" color="blue" />}
       position="top center"
       content={
         <List.Item>
-          <List.Content>
-            <Label color="blue" horizontal>
-              {index}
-            </Label>{" "}
-            {text}
-          </List.Content>
+          <List.Content>{text}</List.Content>
         </List.Item>
       }
     />
   );
 };
 
-export default function ManipulationAnalysis(): JSX.Element {
+export default function ManipulateAnalysis(): JSX.Element {
   const history = useHistory();
   const query = useQuery();
 
-  const [alphaAdjust, setAlphaAdjust] = useState(true);
-  const [alphaRotate, setAlphaRotate] = useState(true);
-  const [alphaInvert, setAlphaInvert] = useState(true);
-  const [alphaGrayscale, setAlphaGrayscale] = useState(true);
+  const [alphaAdjust, setAlphaAdjust] = useState(query.alpha ? JSON.parse(query.alpha)[0] : true);
+  const [alphaRotate, setAlphaRotate] = useState(query.alpha ? JSON.parse(query.alpha)[1] : true);
+  const [alphaInvert, setAlphaInvert] = useState(query.alpha ? JSON.parse(query.alpha)[2] : true);
+  const [alphaGrayscale, setAlphaGrayscale] = useState(query.alpha ? JSON.parse(query.alpha)[3] : true);
 
   const [color, setColor] = useState(CM(query.color ?? "hsla(180, 50%, 50%, 0.5)"));
   const [incrementColor, setIncrementColor] = useState(
@@ -99,7 +94,7 @@ export default function ManipulationAnalysis(): JSX.Element {
     const { h, s, l, a } = incrementColorDebounce.hsla();
     const color = colorDebounce.stringHEX().slice(1).toLowerCase();
     history.replace({
-      pathname: "/manipulation",
+      pathname: "/manipulate",
       search: `?color=${color}&hueBy=${h.toFixed(2)}&satBy=${s.toFixed(2)}&lightBy=${l.toFixed(2)}&alphaBy=${(
         a * 100
       ).toFixed(2)}&isIncrement=${isIncrement}&alpha=[${[alphaAdjust, alphaRotate, alphaInvert, alphaGrayscale].join(
@@ -157,9 +152,9 @@ export default function ManipulationAnalysis(): JSX.Element {
             <Grid.Column width={8}>
               <Grid textAlign="center">
                 <Grid.Row>
-                  <Header>Adjust</Header>
+                  <Header as="h2">Adjust</Header>
                   <Spacers width="4px" />
-                  <Information index={2} text={INFORMATIVE_TEXT.adjust} />
+                  <Information text={INFORMATIVE_TEXT.adjust} />
                 </Grid.Row>
               </Grid>
 
@@ -173,20 +168,23 @@ export default function ManipulationAnalysis(): JSX.Element {
 
               <Swatch
                 title={adjust.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaAdjust })}
-                $radius={75}
-                $borderRadius="4px"
+                position="relative"
                 background={adjust.stringHSL()}
                 onClick={() => setColor(adjust)}
+                $radius={75}
+                $borderRadius="4px"
                 $cursor="pointer"
-              />
+              >
+                <SwatchCounter>2</SwatchCounter>
+              </Swatch>
             </Grid.Column>
 
             <Grid.Column width={8}>
               <Grid textAlign="center">
                 <Grid.Row>
-                  <Header>Rotate</Header>
+                  <Header as="h2">Rotate</Header>
                   <Spacers width="4px" />
-                  <Information index={3} text={INFORMATIVE_TEXT.rotate} />
+                  <Information text={INFORMATIVE_TEXT.rotate} />
                 </Grid.Row>
               </Grid>
 
@@ -200,12 +198,15 @@ export default function ManipulationAnalysis(): JSX.Element {
 
               <Swatch
                 title={rotate.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaRotate })}
-                $radius={75}
-                $borderRadius="4px"
+                position="relative"
                 background={rotate.stringHSL()}
                 onClick={() => setColor(rotate)}
+                $radius={75}
+                $borderRadius="4px"
                 $cursor="pointer"
-              />
+              >
+                <SwatchCounter>3</SwatchCounter>
+              </Swatch>
             </Grid.Column>
           </Grid.Row>
           <Divider />
@@ -213,9 +214,9 @@ export default function ManipulationAnalysis(): JSX.Element {
             <Grid.Column width={8}>
               <Grid textAlign="center">
                 <Grid.Row>
-                  <Header>Invert</Header>
+                  <Header as="h2">Invert</Header>
                   <Spacers width="4px" />
-                  <Information index={4} text={INFORMATIVE_TEXT.invert} />
+                  <Information text={INFORMATIVE_TEXT.invert} />
                 </Grid.Row>
               </Grid>
 
@@ -229,20 +230,23 @@ export default function ManipulationAnalysis(): JSX.Element {
 
               <Swatch
                 title={invert.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaInvert })}
-                $radius={75}
-                $borderRadius="4px"
+                position="relative"
                 background={invert.stringHSL()}
                 onClick={() => setColor(invert)}
+                $radius={75}
+                $borderRadius="4px"
                 $cursor="pointer"
-              />
+              >
+                <SwatchCounter>4</SwatchCounter>
+              </Swatch>
             </Grid.Column>
 
             <Grid.Column width={8}>
               <Grid textAlign="center">
                 <Grid.Row>
-                  <Header>Grayscale</Header>
+                  <Header as="h2">Grayscale</Header>
                   <Spacers width="4px" />
-                  <Information index={5} text={INFORMATIVE_TEXT.grayscale} />
+                  <Information text={INFORMATIVE_TEXT.grayscale} />
                 </Grid.Row>
               </Grid>
 
@@ -256,12 +260,15 @@ export default function ManipulationAnalysis(): JSX.Element {
 
               <Swatch
                 title={grayscale.stringHSL({ precision: [2, 2, 2, 2], alpha: alphaGrayscale })}
-                $radius={75}
-                $borderRadius="4px"
+                position="relative"
                 background={grayscale.stringHSL()}
                 onClick={() => setColor(grayscale)}
+                $radius={75}
+                $borderRadius="4px"
                 $cursor="pointer"
-              />
+              >
+                <SwatchCounter>5</SwatchCounter>
+              </Swatch>
             </Grid.Column>
           </Grid.Row>
         </Grid>

--- a/src/components/Analysis/ManipulationAnalysis.tsx
+++ b/src/components/Analysis/ManipulationAnalysis.tsx
@@ -177,7 +177,7 @@ export default function ManipulationAnalysis(): JSX.Element {
                 $borderRadius="4px"
                 background={adjust.stringHSL()}
                 onClick={() => setColor(adjust)}
-                $clickable
+                $cursor="pointer"
               />
             </Grid.Column>
 
@@ -204,7 +204,7 @@ export default function ManipulationAnalysis(): JSX.Element {
                 $borderRadius="4px"
                 background={rotate.stringHSL()}
                 onClick={() => setColor(rotate)}
-                $clickable
+                $cursor="pointer"
               />
             </Grid.Column>
           </Grid.Row>
@@ -233,7 +233,7 @@ export default function ManipulationAnalysis(): JSX.Element {
                 $borderRadius="4px"
                 background={invert.stringHSL()}
                 onClick={() => setColor(invert)}
-                $clickable
+                $cursor="pointer"
               />
             </Grid.Column>
 
@@ -260,7 +260,7 @@ export default function ManipulationAnalysis(): JSX.Element {
                 $borderRadius="4px"
                 background={grayscale.stringHSL()}
                 onClick={() => setColor(grayscale)}
-                $clickable
+                $cursor="pointer"
               />
             </Grid.Column>
           </Grid.Row>

--- a/src/components/Analysis/ManipulationAnalysis.tsx
+++ b/src/components/Analysis/ManipulationAnalysis.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from "react";
+import { Container, Dropdown, Grid, Header } from "semantic-ui-react";
+import ColorSelectorWidget from "../ColorSelectorWidget";
+import useDebounce from "../../hooks/useDebounce";
+import { Swatch } from "../../styles/Swatch";
+import { useHistory } from "react-router";
+import useQuery from "../../hooks/useQuery";
+import useSliderChange from "../../hooks/useSliderChange";
+import ColorIndicator from "../ColorIndicator";
+import Spacers from "../Spacers";
+import { ManipulationSample } from "../../utils/codeSamples";
+import CodeModal from "./CodeModal";
+import addColor from "../../utils/addColor";
+import CM from "colormaster";
+
+const ColorAdjustmentOpts = [
+  {
+    key: "inc",
+    text: "Increment",
+    value: "inc"
+  },
+  {
+    key: "dec",
+    text: "Decrement",
+    value: "dec"
+  }
+];
+
+export default function ManipulationAnalysis(): JSX.Element {
+  const history = useHistory();
+  const query = useQuery();
+
+  const [alpha, setAlpha] = useState(true);
+  const [color, setColor] = useState(CM(query.color ?? "hsla(180, 50%, 50%, 0.5)"));
+  const [incrementColor, setIncrementColor] = useState(
+    CM(`hsla(${query.hueBy ?? 0.01}, ${query.satBy ?? 0.01}%, ${query.lightBy ?? 0.01}%, ${query.alphaBy ?? 1e-4})`)
+  );
+  const [isIncrement, setIsIncrement] = useState(true);
+  const [invert, setInvert] = useState(CM(color.hsla()).invert({ alpha }));
+  const [grayscale, setGrayscale] = useState(CM(color.rgba()).grayscale());
+  const [rotate, setRotate] = useState(CM(color.hsla()).rotate((isIncrement ? 1 : -1) * incrementColor.hue));
+
+  const [swatchColor, setSwatchColor] = useState(addColor(color, incrementColor, isIncrement));
+
+  const colorDebounce = useDebounce(color, 100);
+  const incrementColorDebounce = useDebounce(incrementColor, 100);
+  const currentSliders = useSliderChange(incrementColor, setIncrementColor, "hsl", alpha, "0.01");
+
+  useEffect(() => {
+    setColor(colorDebounce);
+    setInvert(CM(colorDebounce.hsla()).invert({ alpha }));
+    setGrayscale(CM(colorDebounce.rgba()).grayscale());
+    setRotate(CM(colorDebounce.hsla()).rotate((isIncrement ? 1 : -1) * incrementColor.hue));
+  }, [colorDebounce, incrementColor, alpha, isIncrement]);
+
+  useEffect(() => {
+    setSwatchColor(addColor(color, incrementColor, isIncrement));
+  }, [color, incrementColor, isIncrement]);
+
+  useEffect(() => {
+    const { h, s, l, a } = incrementColorDebounce.hsla();
+    const color = colorDebounce.stringHEX().slice(1).toLowerCase();
+    history.replace({
+      pathname: "/manipulation",
+      search: `?color=${color}&hueBy=${h.toFixed(2)}&satBy=${s.toFixed(2)}&lightBy=${l.toFixed(2)}&alphaBy=${a.toFixed(
+        4
+      )}`
+    });
+  }, [history, colorDebounce, incrementColorDebounce]);
+
+  return (
+    <Grid verticalAlign="middle" stackable>
+      <Grid.Column width={5}>
+        <ColorSelectorWidget
+          color={color}
+          setColor={setColor}
+          initPicker="wheel"
+          initColorspace="hsl"
+          harmony={[color, swatchColor, rotate, grayscale, invert]}
+        />
+      </Grid.Column>
+
+      <Spacers height="37px" />
+
+      <Grid.Column width={5}>
+        <Header textAlign="center">
+          <Dropdown
+            value={isIncrement ? "inc" : "dec"}
+            compact
+            selection
+            options={ColorAdjustmentOpts}
+            onChange={() => setIsIncrement(!isIncrement)}
+          />
+          <Spacers width="4px" />
+          By
+        </Header>
+
+        {currentSliders.sliders}
+
+        <Spacers height="32px" />
+
+        <Container textAlign="center">
+          <CodeModal code={ManipulationSample(colorDebounce, incrementColorDebounce, isIncrement, alpha)} />
+        </Container>
+      </Grid.Column>
+
+      <Grid.Column width={4}>
+        <Grid verticalAlign="middle" textAlign="center">
+          <ColorIndicator
+            color={swatchColor.stringHSL({ precision: [2, 2, 2, 2], alpha })}
+            alpha={alpha}
+            setAlpha={setAlpha}
+          />
+        </Grid>
+
+        <Spacers height="20px" />
+
+        <Grid columns="equal" textAlign="center" stackable>
+          <Grid.Row>
+            <Grid.Column>
+              <Header>Adjust</Header>
+              <Swatch
+                title={swatchColor.stringHSL({ precision: [2, 2, 2, 2] })}
+                $radius={75}
+                $borderRadius="4px"
+                background={swatchColor.stringHSL()}
+                onClick={() => setColor(swatchColor)}
+                $clickable
+              />
+            </Grid.Column>
+
+            <Grid.Column>
+              <Header>Grayscale</Header>
+              <Swatch
+                title={grayscale.stringRGB({ precision: [2, 2, 2, 2] })}
+                $radius={75}
+                $borderRadius="4px"
+                background={grayscale.stringHSL()}
+                onClick={() => setColor(grayscale)}
+                $clickable
+              />
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column>
+              <Header>Rotate</Header>
+              <Swatch
+                title={rotate.stringHSL({ precision: [2, 2, 2, 2] })}
+                $radius={75}
+                $borderRadius="4px"
+                background={rotate.stringHSL()}
+                onClick={() => setColor(rotate)}
+                $clickable
+              />
+            </Grid.Column>
+
+            <Grid.Column>
+              <Header>Invert</Header>
+              <Swatch
+                title={invert.stringHSL({ precision: [2, 2, 2, 2] })}
+                $radius={75}
+                $borderRadius="4px"
+                background={invert.stringHSL()}
+                onClick={() => setColor(invert)}
+                $clickable
+              />
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Grid.Column>
+    </Grid>
+  );
+}

--- a/src/components/Analysis/MixAnalysis.tsx
+++ b/src/components/Analysis/MixAnalysis.tsx
@@ -92,7 +92,7 @@ export default function MixAnalysis(): JSX.Element {
           </Header>
         </Divider>
 
-        <Spacers height="20px" />
+        <Spacers height="16px" />
 
         <Grid verticalAlign="middle" textAlign="center">
           <Grid.Column computer={8} mobile={14}>
@@ -100,7 +100,7 @@ export default function MixAnalysis(): JSX.Element {
           </Grid.Column>
         </Grid>
 
-        <Divider hidden />
+        <Spacers height="8px" />
 
         <Grid.Row>
           <Swatch
@@ -115,17 +115,7 @@ export default function MixAnalysis(): JSX.Element {
           />
         </Grid.Row>
 
-        <Divider hidden />
-
-        <Grid.Row textAlign="left">
-          <Header>
-            <Label color="teal" size="big">
-              Color Space
-            </Label>
-          </Header>
-        </Grid.Row>
-
-        <Spacers height="10px" />
+        <Spacers height="4px" />
 
         <Grid.Row>
           <Dropdown

--- a/src/components/Analysis/MixAnalysis.tsx
+++ b/src/components/Analysis/MixAnalysis.tsx
@@ -105,8 +105,8 @@ export default function MixAnalysis(): JSX.Element {
         <Grid.Row>
           <Swatch
             title={mix}
-            radius={75}
-            borderRadius="4px"
+            $radius={75}
+            $borderRadius="4px"
             display="inline-block"
             position="relative"
             background={mix}

--- a/src/components/Analysis/MixAnalysis.tsx
+++ b/src/components/Analysis/MixAnalysis.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Divider, Dropdown, Grid, Header, Icon, Label, Message, Popup } from "semantic-ui-react";
+import { Divider, Dropdown, Grid, Header, Icon, Label, Popup } from "semantic-ui-react";
 import ColorSelectorWidget from "../ColorSelectorWidget";
 import useDebounce from "../../hooks/useDebounce";
 import CodeModal from "./CodeModal";
@@ -9,10 +9,10 @@ import { MixSample } from "../../utils/codeSamples";
 import CM, { extendPlugins } from "colormaster";
 import MixPlugin from "colormaster/plugins/mix";
 import { TFormat } from "colormaster/types";
-import useCopyToClipboard from "../../hooks/useCopytoClipboard";
-import styled from "styled-components";
 import { useHistory } from "react-router";
 import useQuery from "../../hooks/useQuery";
+import ColorIndicator from "../ColorIndicator";
+import Spacers from "../Spacers";
 
 extendPlugins([MixPlugin]);
 
@@ -21,12 +21,6 @@ type TFormatDropdown = Exclude<TFormat, "invalid" | "name">;
 const colorspaceOpts = ["rgb", "hex", "hsl", "hsv", "hwb", "lab", "lch", "luv", "uvw", "ryb", "cmyk", "xyz"].map(
   (value, i) => ({ key: i, text: value.toUpperCase(), value })
 );
-
-const StyledDropdown = styled(Dropdown)`
-  && {
-    margin: 0 6px;
-  }
-`;
 
 export default function MixAnalysis(): JSX.Element {
   const history = useHistory();
@@ -38,17 +32,16 @@ export default function MixAnalysis(): JSX.Element {
   const [colorspace, setColorspace] = useState<TFormatDropdown>(
     (colorspaceOpts.find((item) => item.value === query.colorspace)?.value as TFormatDropdown) ?? "luv"
   );
-  const [mix, setMix] = useState(primary.mix({ color: secondary, ratio, colorspace }).stringHSL());
+  const [alpha, setAlpha] = useState(true);
+  const [mix, setMix] = useState(primary.mix({ color: secondary, ratio, colorspace }).stringHSL({ alpha }));
 
   const primaryDebounce = useDebounce(primary, 100);
   const secondaryDebounce = useDebounce(secondary, 100);
   const ratioDebounce = useDebounce(ratio, 100);
 
-  const [copy, setCopy] = useCopyToClipboard();
-
   useEffect(() => {
-    setMix(primary.mix({ color: secondary, ratio, colorspace }).stringHSL());
-  }, [primary, secondary, ratio, colorspace]);
+    setMix(primary.mix({ color: secondary, ratio, colorspace }).stringHSL({ alpha }));
+  }, [primary, secondary, ratio, colorspace, alpha]);
 
   useEffect(() => {
     history.replace({
@@ -62,107 +55,108 @@ export default function MixAnalysis(): JSX.Element {
 
   return (
     <Grid columns={3} verticalAlign="middle" stackable centered>
-      <Grid.Row>
-        <Grid.Column width={5}>
-          <ColorSelectorWidget color={primary} setColor={setPrimary}>
-            <Label size="big" color="black" attached="top left">
-              Primary
-            </Label>
-          </ColorSelectorWidget>
-        </Grid.Column>
+      <Grid.Column width={5}>
+        <ColorSelectorWidget color={primary} setColor={setPrimary} initPicker="sketch">
+          <Label size="big" color="black" attached="top left">
+            Primary
+          </Label>
+        </ColorSelectorWidget>
+      </Grid.Column>
 
-        <Grid.Column width={6} textAlign="center">
+      <Grid.Column width={6} textAlign="center">
+        <Grid.Row width={6}>
           <Label size="huge" color="teal" horizontal>
             Ratio
           </Label>
+        </Grid.Row>
 
-          <Divider hidden />
+        <Spacers height="12px" />
 
-          <Grid verticalAlign="middle" textAlign="center">
-            <RangeSlider
-              color={secondary.stringHSL()}
-              colorRight={primary.stringHSL()}
-              min="0"
-              max="100"
-              value={ratio * 100}
-              postfix="%"
-              onChange={(e) => setRatio(e.target.valueAsNumber / 100)}
-            />
-          </Grid>
+        <Grid verticalAlign="middle">
+          <RangeSlider
+            color={secondary.stringHSL()}
+            colorRight={primary.stringHSL()}
+            min="0"
+            max="100"
+            value={ratio * 100}
+            postfix="%"
+            onChange={(e) => setRatio(e.target.valueAsNumber / 100)}
+          />
+        </Grid>
 
-          <Divider hidden />
+        <Spacers height="20px" />
 
-          <Divider horizontal>
-            <Header as="h2">
-              <Icon name="arrow circle down" color="teal" size="massive" />
-            </Header>
-          </Divider>
+        <Divider horizontal>
+          <Header as="h2">
+            <Icon name="arrow circle down" color="teal" size="massive" />
+          </Header>
+        </Divider>
 
-          <Divider hidden />
+        <Spacers height="20px" />
 
-          <Grid.Row>
-            <Swatch
-              title={mix}
-              radius={75}
-              borderRadius="4px"
-              display="inline-block"
-              position="relative"
-              background={mix}
-              $clickable
-              tabIndex={0}
-              onClick={() => setCopy(mix)}
-              onBlur={() => setCopy("")}
-            />
-          </Grid.Row>
+        <Grid verticalAlign="middle" textAlign="center">
+          <Grid.Column computer={8} mobile={14}>
+            <ColorIndicator color={mix} alpha={alpha} setAlpha={setAlpha} />
+          </Grid.Column>
+        </Grid>
 
-          <Grid.Row>
-            {copy && (
-              <Message compact positive>
-                <b>Copied to clipboard!</b>
-              </Message>
-            )}
-          </Grid.Row>
+        <Divider hidden />
 
-          <Divider hidden />
+        <Grid.Row>
+          <Swatch
+            title={mix}
+            radius={75}
+            borderRadius="4px"
+            display="inline-block"
+            position="relative"
+            background={mix}
+            tabIndex={0}
+          />
+        </Grid.Row>
 
-          <Grid.Row textAlign="left">
-            <Header>
-              <Label color="teal" size="big">
-                Color Space
-              </Label>
-            </Header>
+        <Divider hidden />
 
-            <StyledDropdown
-              compact
-              search
-              selection
-              options={colorspaceOpts}
-              value={colorspace}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>, { value }: { value: TFormatDropdown }) =>
-                setColorspace(value)
-              }
-            />
-
-            <Popup
-              content="The two colors will be converted to this color space when mixing"
-              position="right center"
-              trigger={<Icon name="info circle" color="teal" size="large" />}
-            />
-          </Grid.Row>
-
-          <Divider hidden />
-
-          <CodeModal code={MixSample(primaryDebounce, secondaryDebounce, ratioDebounce, colorspace)} />
-        </Grid.Column>
-
-        <Grid.Column width={5}>
-          <ColorSelectorWidget color={secondary} setColor={setSecondary}>
-            <Label size="big" color="black" attached="top right">
-              Secondary
+        <Grid.Row textAlign="left">
+          <Header>
+            <Label color="teal" size="big">
+              Color Space
             </Label>
-          </ColorSelectorWidget>
-        </Grid.Column>
-      </Grid.Row>
+          </Header>
+        </Grid.Row>
+
+        <Spacers height="10px" />
+
+        <Grid.Row>
+          <Dropdown
+            compact
+            search
+            selection
+            options={colorspaceOpts}
+            value={colorspace}
+            onChange={(e, { value }) => setColorspace(value as TFormatDropdown)}
+          />
+
+          <Spacers width="4px" />
+
+          <Popup
+            content="The two colors will be converted to this color space when mixing"
+            position="right center"
+            trigger={<Icon name="info circle" color="teal" size="large" />}
+          />
+        </Grid.Row>
+
+        <Divider hidden />
+
+        <CodeModal code={MixSample(primaryDebounce, secondaryDebounce, ratioDebounce, colorspace, alpha)} />
+      </Grid.Column>
+
+      <Grid.Column width={5}>
+        <ColorSelectorWidget color={secondary} setColor={setSecondary} initPicker="sketch">
+          <Label size="big" color="black" attached="top right">
+            Secondary
+          </Label>
+        </ColorSelectorWidget>
+      </Grid.Column>
     </Grid>
   );
 }

--- a/src/components/Analysis/MixAnalysis.tsx
+++ b/src/components/Analysis/MixAnalysis.tsx
@@ -111,6 +111,7 @@ export default function MixAnalysis(): JSX.Element {
             position="relative"
             background={mix}
             tabIndex={0}
+            $cursor="help"
           />
         </Grid.Row>
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,7 +10,7 @@ import useBreakpointMap from "../hooks/useBreakpointMap";
 const ContrastAnalysis = lazy(() => import("./Analysis/ContrastAnalysis"));
 const HarmonyAnalysis = lazy(() => import("./Analysis/HarmonyAnalysis"));
 const MixAnalysis = lazy(() => import("./Analysis/MixAnalysis"));
-const ManipulationAnalysis = lazy(() => import("./Analysis/ManipulationAnalysis"));
+const ManipulateAnalysis = lazy(() => import("./Analysis/ManipulateAnalysis"));
 const A11yStatisticsAnalysis = lazy(() => import("./Analysis/A11yStatisticsAnalysis"));
 
 const StyledContainer = styled(Container)`
@@ -33,7 +33,7 @@ const Content = styled.div.attrs((props: { $mobile: boolean }) => props)`
       : {}}
 `;
 
-const MENU_TABS = ["contrast", "statistics", "harmony", "mix", "manipulation"];
+const MENU_TABS = ["contrast", "statistics", "harmony", "mix", "manipulate"];
 
 export default function App(): JSX.Element {
   const location = useLocation();
@@ -53,7 +53,7 @@ export default function App(): JSX.Element {
         {isMobile && <Divider hidden />}
 
         <Menu pointing secondary>
-          <Dropdown item text="Accessibility">
+          <Dropdown item text={isMobile ? "A11y" : "Accessibility"}>
             <Dropdown.Menu>
               {MENU_TABS.slice(0, 2).map((item) => {
                 const path = "/accessibility/" + item;
@@ -94,7 +94,7 @@ export default function App(): JSX.Element {
             <Route path="/accessibility/statistics" component={A11yStatisticsAnalysis} />
             <Route path="/harmony" component={HarmonyAnalysis} />
             <Route path="/mix" component={MixAnalysis} />
-            <Route path="/manipulation" component={ManipulationAnalysis} />
+            <Route path="/manipulate" component={ManipulateAnalysis} />
             <Redirect from="/" to="/harmony" />
           </Switch>
         </Content>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,7 @@ import useBreakpointMap from "../hooks/useBreakpointMap";
 const ContrastAnalysis = lazy(() => import("./Analysis/ContrastAnalysis"));
 const HarmonyAnalysis = lazy(() => import("./Analysis/HarmonyAnalysis"));
 const MixAnalysis = lazy(() => import("./Analysis/MixAnalysis"));
+const ManipulationAnalysis = lazy(() => import("./Analysis/ManipulationAnalysis"));
 
 const StyledContainer = styled(Container)`
   && {
@@ -31,7 +32,7 @@ const Content = styled.div.attrs((props: { $mobile: boolean }) => props)`
       : {}}
 `;
 
-const MENU_TABS = ["contrast", "harmony", "mix"];
+const MENU_TABS = ["contrast", "harmony", "mix", "manipulation"];
 
 export default function App(): JSX.Element {
   const location = useLocation();
@@ -72,6 +73,7 @@ export default function App(): JSX.Element {
             <Route path="/contrast" component={ContrastAnalysis} />
             <Route path="/harmony" component={HarmonyAnalysis} />
             <Route path="/mix" component={MixAnalysis} />
+            <Route path="/manipulation" component={ManipulationAnalysis} />
             <Redirect from="/" to="/harmony" />
           </Switch>
         </Content>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useEffect, useState } from "react";
-import { Container, Divider, Menu } from "semantic-ui-react";
+import { Container, Divider, Dropdown, Menu } from "semantic-ui-react";
 import styled from "styled-components";
 import { GlobalStyle } from "../styles/Global";
 import Loading from "./Loading";
@@ -11,6 +11,7 @@ const ContrastAnalysis = lazy(() => import("./Analysis/ContrastAnalysis"));
 const HarmonyAnalysis = lazy(() => import("./Analysis/HarmonyAnalysis"));
 const MixAnalysis = lazy(() => import("./Analysis/MixAnalysis"));
 const ManipulationAnalysis = lazy(() => import("./Analysis/ManipulationAnalysis"));
+const A11yStatisticsAnalysis = lazy(() => import("./Analysis/A11yStatisticsAnalysis"));
 
 const StyledContainer = styled(Container)`
   && {
@@ -32,7 +33,7 @@ const Content = styled.div.attrs((props: { $mobile: boolean }) => props)`
       : {}}
 `;
 
-const MENU_TABS = ["contrast", "harmony", "mix", "manipulation"];
+const MENU_TABS = ["contrast", "statistics", "harmony", "mix", "manipulation"];
 
 export default function App(): JSX.Element {
   const location = useLocation();
@@ -52,7 +53,26 @@ export default function App(): JSX.Element {
         {isMobile && <Divider hidden />}
 
         <Menu pointing secondary>
-          {MENU_TABS.map((item) => {
+          <Dropdown item text="Accessibility">
+            <Dropdown.Menu>
+              {MENU_TABS.slice(0, 2).map((item) => {
+                const path = "/accessibility/" + item;
+                return (
+                  <Dropdown.Item
+                    as={NavLink}
+                    key={path}
+                    to={path}
+                    active={active === path}
+                    onClick={() => setActive(path)}
+                  >
+                    {item[0].toUpperCase() + item.slice(1)}
+                  </Dropdown.Item>
+                );
+              })}
+            </Dropdown.Menu>
+          </Dropdown>
+
+          {MENU_TABS.slice(2).map((item) => {
             const path = "/" + item;
             return (
               <Menu.Item as={NavLink} key={path} to={path} active={active === path} onClick={() => setActive(path)}>
@@ -70,7 +90,8 @@ export default function App(): JSX.Element {
 
         <Content $mobile={isMobile}>
           <Switch>
-            <Route path="/contrast" component={ContrastAnalysis} />
+            <Route path="/accessibility/contrast" component={ContrastAnalysis} />
+            <Route path="/accessibility/statistics" component={A11yStatisticsAnalysis} />
             <Route path="/harmony" component={HarmonyAnalysis} />
             <Route path="/mix" component={MixAnalysis} />
             <Route path="/manipulation" component={ManipulationAnalysis} />

--- a/src/components/BreadcrumbPath.tsx
+++ b/src/components/BreadcrumbPath.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { Breadcrumb } from "semantic-ui-react";
+import styled from "styled-components";
+
+export const StyledBreadcrumbSection = styled(Breadcrumb.Section)`
+  &&&& {
+    cursor: not-allowed;
+  }
+`;
+
+export default function BreadcrumbPath({ path }: { path: "Contrast" | "Statistics" }): JSX.Element {
+  return (
+    <Breadcrumb size="large">
+      <StyledBreadcrumbSection link>Accessibility</StyledBreadcrumbSection>
+      <Breadcrumb.Divider />
+      <StyledBreadcrumbSection active>{path}</StyledBreadcrumbSection>
+    </Breadcrumb>
+  );
+}

--- a/src/components/ColorIndicator.tsx
+++ b/src/components/ColorIndicator.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from "react";
+import { Popup, Icon, Grid, Checkbox, Input } from "semantic-ui-react";
+import styled from "styled-components";
+import useBreakpointMap from "../hooks/useBreakpointMap";
+import useCopyToClipboard from "../hooks/useCopytoClipboard";
+import Spacers from "./Spacers";
+
+const StyledColorDisplay = styled(Input).attrs(
+  (props: { $mobile: boolean; action: { color: string; [key: string]: unknown } }) => props
+)`
+  && {
+    & > input {
+      text-align: center;
+      font-size: ${(props) => (props.$mobile ? "0.95em" : "1em")};
+      padding: 0;
+    }
+
+    & .button:hover,
+    & .button:focus {
+      background-color: ${(props) => (props.action.color === "teal" ? "rgba(0, 196, 196, 1)" : "rgba(0, 196, 0, 1)")};
+    }
+  }
+`;
+
+export default function ColorIndicator({
+  color,
+  alpha,
+  setAlpha
+}: {
+  color: string;
+  alpha: boolean;
+  setAlpha: React.Dispatch<React.SetStateAction<boolean>>;
+}): JSX.Element {
+  const [copy, setCopy] = useCopyToClipboard();
+  const { isMobile } = useBreakpointMap();
+
+  const copyAction = useMemo(
+    () =>
+      function (text: string) {
+        return {
+          icon: (
+            <Popup
+              content="Copy to clipboard"
+              position="top center"
+              inverted
+              trigger={<Icon name={copy ? "check circle" : "copy"} />}
+            />
+          ),
+          color: copy ? "green" : "teal",
+          onClick: () => setCopy(text),
+          onBlur: () => setCopy("")
+        };
+      },
+    [copy, setCopy]
+  );
+
+  return (
+    <Grid.Row columns={2}>
+      <Grid.Column computer={12}>
+        <StyledColorDisplay
+          type="text"
+          value={color}
+          spellCheck={false}
+          size="large"
+          readOnly
+          fluid
+          action={copyAction(color)}
+          $mobile={isMobile}
+        />
+      </Grid.Column>
+
+      <Spacers height="12px" />
+
+      <Grid.Column computer={2}>
+        <Checkbox label="Alpha" checked={alpha} onChange={() => setAlpha(!alpha)} />
+      </Grid.Column>
+    </Grid.Row>
+  );
+}

--- a/src/components/ColorIndicator.tsx
+++ b/src/components/ColorIndicator.tsx
@@ -1,9 +1,13 @@
 import React, { useMemo } from "react";
-import { Popup, Icon, Grid, Checkbox, Input } from "semantic-ui-react";
+import { Popup, Icon, Grid, Checkbox, Input, Header } from "semantic-ui-react";
 import styled from "styled-components";
 import useBreakpointMap from "../hooks/useBreakpointMap";
 import useCopyToClipboard from "../hooks/useCopytoClipboard";
 import Spacers from "./Spacers";
+import CM, { extendPlugins } from "colormaster";
+import NamePlugin from "colormaster/plugins/name";
+
+extendPlugins([NamePlugin]);
 
 const StyledColorDisplay = styled(Input).attrs(
   (props: { $mobile: boolean; action: { color: string; [key: string]: unknown } }) => props
@@ -25,11 +29,13 @@ const StyledColorDisplay = styled(Input).attrs(
 export default function ColorIndicator({
   color,
   alpha,
-  setAlpha
+  setAlpha,
+  showName = true
 }: {
   color: string;
   alpha: boolean;
   setAlpha: React.Dispatch<React.SetStateAction<boolean>>;
+  showName?: boolean;
 }): JSX.Element {
   const [copy, setCopy] = useCopyToClipboard();
   const { isMobile } = useBreakpointMap();
@@ -55,25 +61,39 @@ export default function ColorIndicator({
   );
 
   return (
-    <Grid.Row columns={2}>
-      <Grid.Column computer={12}>
-        <StyledColorDisplay
-          type="text"
-          value={color}
-          spellCheck={false}
-          size="large"
-          readOnly
-          fluid
-          action={copyAction(color)}
-          $mobile={isMobile}
-        />
-      </Grid.Column>
+    <>
+      {showName && (
+        <>
+          <Grid.Row>
+            <Header as="h3" color="grey">
+              {CM(color).name({ exact: false })}
+            </Header>
+          </Grid.Row>
 
-      <Spacers height="12px" />
+          <Spacers height="6px" />
+        </>
+      )}
 
-      <Grid.Column computer={2}>
-        <Checkbox label="Alpha" checked={alpha} onChange={() => setAlpha(!alpha)} />
-      </Grid.Column>
-    </Grid.Row>
+      <Grid.Row columns={2}>
+        <Grid.Column computer={12}>
+          <StyledColorDisplay
+            type="text"
+            value={color}
+            spellCheck={false}
+            size="large"
+            readOnly
+            fluid
+            action={copyAction(color)}
+            $mobile={isMobile}
+          />
+        </Grid.Column>
+
+        <Spacers height="12px" />
+
+        <Grid.Column computer={2}>
+          <Checkbox label="Alpha" checked={alpha} onChange={() => setAlpha(!alpha)} />
+        </Grid.Column>
+      </Grid.Row>
+    </>
   );
 }

--- a/src/components/ColorSelectorWidget.tsx
+++ b/src/components/ColorSelectorWidget.tsx
@@ -146,7 +146,7 @@ export default function ColorSelectorWidget({
 
       <Grid verticalAlign="middle" centered stackable>
         <Grid.Row>
-          <Swatch $radius={50} background={color.stringHSL()} title={color.stringHSL()} />
+          <Swatch $radius={50} background={color.stringHSL()} title={color.stringHSL()} $cursor="help" />
         </Grid.Row>
 
         <Grid.Row>

--- a/src/components/ColorSelectorWidget.tsx
+++ b/src/components/ColorSelectorWidget.tsx
@@ -1,17 +1,18 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useState } from "react";
 import { Button, Divider, Dropdown, Grid, Header, Icon, Segment } from "semantic-ui-react";
 import styled from "styled-components";
 import { Swatch } from "../styles/Swatch";
-import HSLSliderGroup from "./Sliders/HSLSliderGroup";
-import RGBSliderGroup from "./Sliders/RGBSliderGroup";
-import CM, { ColorMaster } from "colormaster";
-import { Ihsla, Irgba, TChannel, TChannelHSL, TFormat } from "colormaster/types";
+import { TFormat } from "colormaster/types";
 import useBreakpointMap from "../hooks/useBreakpointMap";
 import SketchPicker from "./Pickers/SketchPicker";
 import WheelPicker from "./Pickers/WheelPicker";
-import HEXSliderGroup from "./Sliders/HEXSliderGroup";
 import ColorIndicator from "./ColorIndicator";
 import useDebounce from "../hooks/useDebounce";
+import useSliderChange from "../hooks/useSliderChange";
+import CM, { ColorMaster, extendPlugins } from "colormaster";
+import NamePlugin from "colormaster/plugins/name";
+
+extendPlugins([NamePlugin]);
 
 type TValidColorspace = Exclude<TFormat, "name" | "invalid">;
 type TValidPicker = "slider" | "sketch" | "wheel";
@@ -120,57 +121,8 @@ export default function ColorSelectorWidget({
   const [picker, setPicker] = useState(pickerOpts.find((x) => x.key === initPicker) ?? pickerOpts[0]);
 
   const colorNameDebounce = useDebounce(color.name({ exact: false }), 100);
-
   const { isMobile } = useBreakpointMap();
-
-  const handleSliderChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>, type: TChannel | TChannelHSL) => {
-      const val = Number.isNaN(e.target.valueAsNumber)
-        ? e.target.value.length > 0
-          ? parseInt(e.target.value, 16)
-          : 0
-        : e.target.valueAsNumber;
-
-      const { r, g, b } = color.rgba();
-      const { h, s, l } = color.hsla();
-
-      const newColor: Irgba | Ihsla = ["red", "green", "blue"].includes(type)
-        ? { r: type === "red" ? val : r, g: type === "green" ? val : g, b: type === "blue" ? val : b, a: 1 }
-        : {
-            h: type === "hue" ? Math.max(0, Math.min(val, 359.99)) : h,
-            s: type === "saturation" ? val : s,
-            l: type === "lightness" ? val : l,
-            a: 1
-          };
-
-      newColor.a = type === "alpha" ? val / (colorspace.key === "hex" ? 255 : 100) : color.alpha;
-
-      setColor(CM(newColor));
-    },
-    [color, setColor, colorspace]
-  );
-
-  const currentSliders = useMemo(() => {
-    const possibleSliders = [
-      {
-        type: "rgb",
-        colorStr: color.stringRGB({ alpha, precision: [2, 2, 2, 2] }),
-        sliders: <RGBSliderGroup rgb={color.rgba()} onChange={handleSliderChange} />
-      },
-      {
-        type: "hex",
-        colorStr: color.stringHEX({ alpha }),
-        sliders: <HEXSliderGroup color={color} onChange={handleSliderChange} />
-      },
-      {
-        type: "hsl",
-        colorStr: color.stringHSL({ alpha, precision: [2, 2, 2, 2] }),
-        sliders: <HSLSliderGroup hsl={color.hsla()} onChange={handleSliderChange} />
-      }
-    ];
-
-    return possibleSliders.filter((slider) => slider.type === colorspace.key)[0];
-  }, [colorspace, color, alpha, handleSliderChange]);
+  const currentSliders = useSliderChange(color, setColor, colorspace.key, alpha);
 
   const handleDropdownAdjustment = (dir: "up" | "down", type: "picker" | "colorspace") => {
     const numOptions = Object.keys(type === "colorspace" ? colorspaceOpts : pickerOpts).length;

--- a/src/components/ColorSelectorWidget.tsx
+++ b/src/components/ColorSelectorWidget.tsx
@@ -228,7 +228,7 @@ export default function ColorSelectorWidget({
           </Grid.Column>
         </Grid.Row>
 
-        <ColorIndicator color={currentSliders.colorStr} alpha={alpha} setAlpha={setAlpha} />
+        <ColorIndicator color={currentSliders.colorStr} showName={false} alpha={alpha} setAlpha={setAlpha} />
       </Grid>
 
       <Divider hidden />

--- a/src/components/ColorSelectorWidget.tsx
+++ b/src/components/ColorSelectorWidget.tsx
@@ -194,7 +194,7 @@ export default function ColorSelectorWidget({
 
       <Grid verticalAlign="middle" centered stackable>
         <Grid.Row>
-          <Swatch radius={50} background={color.stringHSL()} title={color.stringHSL()} />
+          <Swatch $radius={50} background={color.stringHSL()} title={color.stringHSL()} />
         </Grid.Row>
 
         <Grid.Row>
@@ -220,9 +220,9 @@ export default function ColorSelectorWidget({
                 className="swatch-color"
                 key={background + "-swatch"}
                 title={background}
-                radius={15}
-                borderColor="rgba(0,0,0,0.3)"
-                borderRadius="4px"
+                $radius={15}
+                $borderColor="rgba(0,0,0,0.3)"
+                $borderRadius="4px"
                 display="inline-block"
                 background={background}
                 onClick={() => setColor(CM(background))}

--- a/src/components/ColorSelectorWidget.tsx
+++ b/src/components/ColorSelectorWidget.tsx
@@ -122,7 +122,7 @@ export default function ColorSelectorWidget({
 
   const colorNameDebounce = useDebounce(color.name({ exact: false }), 100);
   const { isMobile } = useBreakpointMap();
-  const currentSliders = useSliderChange(color, setColor, colorspace.key, alpha);
+  const currentSliders = useSliderChange({ color, setColor, colorspace: colorspace.key, alpha });
 
   const handleDropdownAdjustment = (dir: "up" | "down", type: "picker" | "colorspace") => {
     const numOptions = Object.keys(type === "colorspace" ? colorspaceOpts : pickerOpts).length;

--- a/src/components/ColorSelectorWidget.tsx
+++ b/src/components/ColorSelectorWidget.tsx
@@ -1,27 +1,33 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Button, Checkbox, Divider, Dropdown, Grid, Icon, Input, Popup, Segment } from "semantic-ui-react";
+import { Button, Divider, Dropdown, Grid, Header, Icon, Segment } from "semantic-ui-react";
 import styled from "styled-components";
 import { Swatch } from "../styles/Swatch";
 import HSLSliderGroup from "./Sliders/HSLSliderGroup";
 import RGBSliderGroup from "./Sliders/RGBSliderGroup";
 import CM, { ColorMaster } from "colormaster";
-import { Ihsla, Irgba, TChannel, TChannelHSL } from "colormaster/types";
+import { Ihsla, Irgba, TChannel, TChannelHSL, TFormat } from "colormaster/types";
 import useBreakpointMap from "../hooks/useBreakpointMap";
 import SketchPicker from "./Pickers/SketchPicker";
 import WheelPicker from "./Pickers/WheelPicker";
 import HEXSliderGroup from "./Sliders/HEXSliderGroup";
-import useCopyToClipboard from "../hooks/useCopytoClipboard";
+import ColorIndicator from "./ColorIndicator";
+import useDebounce from "../hooks/useDebounce";
 
-const colorspaceOptions = [
-  { key: 1, text: "RGB", value: 1 },
-  { key: 2, text: "HEX", value: 2 },
-  { key: 3, text: "HSL", value: 3 }
+type TValidColorspace = Exclude<TFormat, "name" | "invalid">;
+type TValidPicker = "slider" | "sketch" | "wheel";
+type TColorspaceOpts = { key: TValidColorspace; text: `${Uppercase<TValidColorspace>}`; value: number }[];
+type TPickerOpts = { key: TValidPicker; text: `${Uppercase<TValidPicker>}`; value: number }[];
+
+const colorspaceOpts: TColorspaceOpts = [
+  { key: "rgb", text: "RGB", value: 1 },
+  { key: "hex", text: "HEX", value: 2 },
+  { key: "hsl", text: "HSL", value: 3 }
 ];
 
-const pickerTypeOptions = [
-  { key: 1, text: "SLIDER", value: 1 },
-  { key: 2, text: "SKETCH", value: 2 },
-  { key: 3, text: "WHEEL", value: 3 }
+const pickerOpts: TPickerOpts = [
+  { key: "slider", text: "SLIDER", value: 1 },
+  { key: "sketch", text: "SKETCH", value: 2 },
+  { key: "wheel", text: "WHEEL", value: 3 }
 ];
 
 const SWATCH_COLORS = [
@@ -43,23 +49,6 @@ const SWATCH_COLORS = [
   "hsla(0, 0%,25%, 1)",
   "hsla(0, 0%, 0%, 1)"
 ];
-
-const StyledColorDisplay = styled(Input).attrs(
-  (props: { $mobile: boolean; action: { color: string; [key: string]: unknown } }) => props
-)`
-  && {
-    & > input {
-      text-align: center;
-      font-size: ${(props) => (props.$mobile ? "0.95em" : "1em")};
-      padding: 0;
-    }
-
-    & .button:hover,
-    & .button:focus {
-      background-color: ${(props) => (props.action.color === "teal" ? "rgba(0, 196, 196, 1)" : "rgba(0, 196, 0, 1)")};
-    }
-  }
-`;
 
 const StyledDropdown = styled(Dropdown)`
   &.ui.selection.dropdown {
@@ -110,8 +99,8 @@ interface IColorSelectorWidget {
   color: ColorMaster;
   setColor: React.Dispatch<React.SetStateAction<ColorMaster>>;
   children?: JSX.Element;
-  initColorspace?: number;
-  initPicker?: number;
+  initColorspace?: TValidColorspace;
+  initPicker?: TValidPicker;
   harmony?: ColorMaster[];
 }
 
@@ -119,17 +108,20 @@ export default function ColorSelectorWidget({
   color,
   setColor,
   children,
-  initColorspace = 1,
-  initPicker = 1,
+  initColorspace = colorspaceOpts[0].key,
+  initPicker = pickerOpts[0].key,
   harmony = undefined
 }: IColorSelectorWidget): JSX.Element {
   const [alpha, setAlpha] = useState(true);
   const [swatchIndex, setSwatchIndex] = useState(0);
-  const [colorspace, setColorspace] = useState(initColorspace);
-  const [pickerType, setPickerType] = useState(initPicker);
+  const [colorspace, setColorspace] = useState(
+    colorspaceOpts.find((x) => x.key === initColorspace) ?? colorspaceOpts[0]
+  );
+  const [picker, setPicker] = useState(pickerOpts.find((x) => x.key === initPicker) ?? pickerOpts[0]);
+
+  const colorNameDebounce = useDebounce(color.name({ exact: false }), 100);
 
   const { isMobile } = useBreakpointMap();
-  const [copy, setCopy] = useCopyToClipboard();
 
   const handleSliderChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>, type: TChannel | TChannelHSL) => {
@@ -151,84 +143,67 @@ export default function ColorSelectorWidget({
             a: 1
           };
 
-      newColor.a = type === "alpha" ? val / (colorspace === 2 ? 255 : 100) : color.alpha;
+      newColor.a = type === "alpha" ? val / (colorspace.key === "hex" ? 255 : 100) : color.alpha;
 
       setColor(CM(newColor));
     },
     [color, setColor, colorspace]
   );
 
-  const copyAction = useMemo(
-    () =>
-      function (text: string) {
-        return {
-          icon: (
-            <Popup
-              content="Copy to clipboard"
-              position="top center"
-              inverted
-              trigger={<Icon name={copy ? "check circle" : "copy"} />}
-            />
-          ),
-          color: copy ? "green" : "teal",
-          onClick: () => setCopy(text),
-          onBlur: () => setCopy("")
-        };
-      },
-    [copy, setCopy]
-  );
-
   const currentSliders = useMemo(() => {
     const possibleSliders = [
       {
-        value: color.stringRGB({ alpha, precision: [2, 2, 2, 2] }),
+        type: "rgb",
+        colorStr: color.stringRGB({ alpha, precision: [2, 2, 2, 2] }),
         sliders: <RGBSliderGroup rgb={color.rgba()} onChange={handleSliderChange} />
       },
       {
-        value: color.stringHEX({ alpha }),
+        type: "hex",
+        colorStr: color.stringHEX({ alpha }),
         sliders: <HEXSliderGroup color={color} onChange={handleSliderChange} />
       },
       {
-        value: color.stringHSL({ alpha, precision: [2, 2, 2, 2] }),
+        type: "hsl",
+        colorStr: color.stringHSL({ alpha, precision: [2, 2, 2, 2] }),
         sliders: <HSLSliderGroup hsl={color.hsla()} onChange={handleSliderChange} />
       }
     ];
 
-    return possibleSliders[colorspace - 1];
+    return possibleSliders.filter((slider) => slider.type === colorspace.key)[0];
   }, [colorspace, color, alpha, handleSliderChange]);
 
-  const handleColorspaceAdjustment = (dir: "up" | "down") => {
-    const numOptions = Object.keys(colorspaceOptions).length;
+  const handleDropdownAdjustment = (dir: "up" | "down", type: "picker" | "colorspace") => {
+    const numOptions = Object.keys(type === "colorspace" ? colorspaceOpts : pickerOpts).length;
+    const value = (type === "colorspace" ? colorspace : picker).value;
+    let newValue = 0;
     if (dir === "down") {
-      setColorspace(colorspace === 1 ? numOptions : colorspace - 1);
+      newValue = value === 1 ? numOptions : value - 1;
     } else {
-      setColorspace(colorspace === numOptions ? 1 : colorspace + 1);
+      newValue = value === numOptions ? 1 : value + 1;
     }
-  };
 
-  const handlePickerAdjustment = (dir: "up" | "down") => {
-    const numOptions = Object.keys(pickerTypeOptions).length;
-    if (dir === "down") {
-      setPickerType(pickerType === 1 ? numOptions : pickerType - 1);
-    } else {
-      setPickerType(pickerType === numOptions ? 1 : pickerType + 1);
-    }
+    if (type === "colorspace") setColorspace(colorspaceOpts[newValue - 1]);
+    else setPicker(pickerOpts[newValue - 1]);
   };
 
   return (
     <Segment>
       {children}
 
+      {isMobile && <Divider hidden />}
+
       <Grid verticalAlign="middle" centered stackable>
         <Grid.Row>
-          <Swatch
-            radius={50}
-            background={colorspace === 1 ? color.stringRGB() : colorspace === 2 ? color.stringHEX() : color.stringHSL()}
-            title={color.stringHSL()}
-          />
+          <Swatch radius={50} background={color.stringHSL()} title={color.stringHSL()} />
         </Grid.Row>
 
-        {isMobile && <Divider hidden />}
+        <Grid.Row>
+          <Grid.Column width={16} textAlign="center">
+            <Header as="h3" color="grey">
+              {colorNameDebounce}
+            </Header>
+          </Grid.Column>
+        </Grid.Row>
 
         <Grid.Row>
           <SwatchSegment>
@@ -267,70 +242,48 @@ export default function ColorSelectorWidget({
         <Grid.Row>
           <Grid.Column computer={1} only="computer">
             <StyledButton vertical>
-              <Button icon="angle up" basic onClick={() => handleColorspaceAdjustment("up")} />
-              <Button icon="angle down" basic onClick={() => handleColorspaceAdjustment("down")} />
+              <Button icon="angle up" basic onClick={() => handleDropdownAdjustment("up", "colorspace")} />
+              <Button icon="angle down" basic onClick={() => handleDropdownAdjustment("down", "colorspace")} />
             </StyledButton>
           </Grid.Column>
 
-          <Grid.Column computer={6}>
-            <StyledDropdown
-              icon={<Icon name="paint brush" color="grey" />}
-              value={colorspace}
-              options={colorspaceOptions}
-              labeled
-              selection
-              scrolling
-              fluid
-              onChange={(e: React.ChangeEvent, { value }: { value: number }) => setColorspace(value)}
-            />
-          </Grid.Column>
-
-          <Grid.Column computer={6}>
-            <StyledDropdown
-              icon={<Icon name="crosshairs" color="grey" />}
-              value={pickerType}
-              options={pickerTypeOptions}
-              labeled
-              selection
-              scrolling
-              fluid
-              onChange={(e: React.ChangeEvent, { value }: { value: number }) => setPickerType(value)}
-            />
-          </Grid.Column>
+          {[{ key: "colorspace" }, { key: "picker" }].map((elem, i) => {
+            return (
+              <Grid.Column key={elem.key + "-column"} computer={6}>
+                <StyledDropdown
+                  icon={<Icon name={i === 0 ? "paint brush" : "crosshairs"} color="grey" />}
+                  value={(i === 0 ? colorspace : picker).value}
+                  options={i === 0 ? colorspaceOpts : pickerOpts}
+                  labeled
+                  selection
+                  scrolling
+                  fluid
+                  onChange={(e: React.ChangeEvent, { value }: { value: number }) =>
+                    i === 0
+                      ? setColorspace({ ...colorspaceOpts[value - 1], value })
+                      : setPicker({ ...pickerOpts[value - 1], value })
+                  }
+                />
+              </Grid.Column>
+            );
+          })}
 
           <Grid.Column computer={1} only="computer">
             <StyledButton vertical>
-              <Button icon="angle up" basic onClick={() => handlePickerAdjustment("up")} />
-              <Button icon="angle down" basic onClick={() => handlePickerAdjustment("down")} />
+              <Button icon="angle up" basic onClick={() => handleDropdownAdjustment("up", "picker")} />
+              <Button icon="angle down" basic onClick={() => handleDropdownAdjustment("down", "picker")} />
             </StyledButton>
           </Grid.Column>
         </Grid.Row>
 
-        <Grid.Row columns={2}>
-          <Grid.Column computer={12}>
-            <StyledColorDisplay
-              type="text"
-              value={currentSliders.value}
-              spellCheck={false}
-              size="large"
-              readOnly
-              fluid
-              action={copyAction(currentSliders.value)}
-              $mobile={isMobile}
-            />
-          </Grid.Column>
-
-          <Grid.Column computer={2}>
-            <Checkbox label="Alpha" checked={alpha} onChange={() => setAlpha(!alpha)} />
-          </Grid.Column>
-        </Grid.Row>
+        <ColorIndicator color={currentSliders.colorStr} alpha={alpha} setAlpha={setAlpha} />
       </Grid>
 
       <Divider hidden />
 
-      {pickerType === 2 ? (
+      {picker.key === "sketch" ? (
         <SketchPicker color={color} setColor={setColor} verticalPickers={!isMobile} />
-      ) : pickerType === 3 ? (
+      ) : picker.key === "wheel" ? (
         <WheelPicker color={color} setColor={setColor} harmony={harmony} verticalPickers={!isMobile} />
       ) : (
         currentSliders.sliders

--- a/src/components/Pickers/WheelPicker.tsx
+++ b/src/components/Pickers/WheelPicker.tsx
@@ -68,7 +68,7 @@ export default function WheelPicker({
       ctxPicker.clearRect(0, 0, radius * 2 + 5, radius * 2 + 5);
 
       const colorArr = harmony ?? [color];
-      colorArr.forEach((c) => {
+      colorArr.forEach((c, i) => {
         const { h, s } = c.hsla();
         ctxPicker.beginPath();
 
@@ -80,11 +80,19 @@ export default function WheelPicker({
         ctxPicker.arc(x, y, pickerRadius, 0, 2 * Math.PI);
 
         const pickerColor = "rgba(0,0,0,0.6)";
-        ctxPicker.fillStyle = c.stringHSL() === color.stringHSL() ? pickerColor : "transparent";
+        ctxPicker.fillStyle = pickerColor;
         ctxPicker.strokeStyle = pickerColor;
         ctxPicker.lineWidth = 1;
         ctxPicker.fill();
         ctxPicker.stroke();
+
+        if (colorArr.length > 1) {
+          ctxPicker.fillStyle = "white";
+          ctxPicker.font = "bold 10px Arial";
+          ctxPicker.textAlign = "center";
+          ctxPicker.textBaseline = "middle";
+          ctxPicker.fillText((i + 1).toString(), x, y);
+        }
       });
     }
   }, [pickerRadius, rotate, color, harmony, ctxPicker]);

--- a/src/components/Sliders/HSLSliderGroup.tsx
+++ b/src/components/Sliders/HSLSliderGroup.tsx
@@ -6,9 +6,10 @@ import RangeSlider from "./RangeSlider";
 interface IHSLSliderGroup {
   hsl: Ihsla;
   onChange: (e: React.ChangeEvent<HTMLInputElement>, type: TChannelHSL) => void;
+  min?: string;
 }
 
-export default function HSLSliderGroup({ hsl, onChange }: IHSLSliderGroup): JSX.Element {
+export default function HSLSliderGroup({ hsl, onChange, min = "0" }: IHSLSliderGroup): JSX.Element {
   const { h, s, l, a } = hsl;
 
   return (
@@ -17,6 +18,7 @@ export default function HSLSliderGroup({ hsl, onChange }: IHSLSliderGroup): JSX.
         value={h}
         color={`hsla(${h}, 100%, 50%, 1)`}
         title="H"
+        min={min}
         max="359.99"
         postfix="&deg;"
         onChange={(e) => onChange(e, "hue")}
@@ -26,6 +28,7 @@ export default function HSLSliderGroup({ hsl, onChange }: IHSLSliderGroup): JSX.
         value={s}
         color={`hsla(${h}, ${s}%, 50%, 1)`}
         title="S"
+        min={min}
         max="100"
         postfix="%"
         onChange={(e) => onChange(e, "saturation")}
@@ -35,6 +38,7 @@ export default function HSLSliderGroup({ hsl, onChange }: IHSLSliderGroup): JSX.
         value={l}
         color={`hsla(0, 0%, ${l - 5}%, 1)`}
         title="L"
+        min={min}
         max="100"
         postfix="%"
         onChange={(e) => onChange(e, "lightness")}
@@ -44,6 +48,7 @@ export default function HSLSliderGroup({ hsl, onChange }: IHSLSliderGroup): JSX.
         value={a * 100}
         color="rgba(0,0,0,0.5)"
         title="A"
+        min={min}
         max="100"
         postfix={"%"}
         onChange={(e) => onChange(e, "alpha")}

--- a/src/components/Sliders/RangeSlider.tsx
+++ b/src/components/Sliders/RangeSlider.tsx
@@ -53,6 +53,7 @@ const NumberInput = styled(Input).attrs(
       left: 0;
       top: 0;
       height: 100%;
+      transform: scaleX(1.05);
 
       &:hover {
         cursor: pointer;

--- a/src/components/SocialMedia.tsx
+++ b/src/components/SocialMedia.tsx
@@ -1,30 +1,35 @@
 import React from "react";
 import { Icon } from "semantic-ui-react";
+import { SemanticCOLORS } from "semantic-ui-react/dist/commonjs/generic";
 import styled from "styled-components";
 
 const LinkIcon = styled(Icon)`
   cursor: pointer;
 `;
 
+const LINKS: { href: string; name: string; color: SemanticCOLORS }[] = [
+  {
+    href: "https://www.github.com/lbragile/ColorMaster",
+    name: "github",
+    color: "black"
+  },
+  {
+    href: "https://www.npmjs.com/package/colormaster",
+    name: "npm",
+    color: "red"
+  }
+];
+
 export default function SocialMedia(): JSX.Element {
   return (
     <React.Fragment>
-      <LinkIcon
-        name="github"
-        size="large"
-        circular
-        title="https://www.github.com/lbragile/ColorMaster"
-        onClick={() => location.assign("https://www.github.com/lbragile/ColorMaster")}
-      />
-
-      <LinkIcon
-        name="npm"
-        size="large"
-        color="red"
-        circular
-        title="https://www.npmjs.com/package/colormaster"
-        onClick={() => location.assign("https://www.npmjs.com/package/colormaster")}
-      />
+      {LINKS.map((link) => {
+        return (
+          <a href={link.href} key={link.href}>
+            <LinkIcon name={link.name} color={link.color} size="large" circular title={link.href} />
+          </a>
+        );
+      })}
     </React.Fragment>
   );
 }

--- a/src/components/Spacers.tsx
+++ b/src/components/Spacers.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import styled from "styled-components";
+
+const Horizontal = styled.span.attrs((props: { $width: string }) => props)`
+  margin: ${(props) => "0 " + props.$width ?? "0"};
+`;
+
+const Vertical = styled.div.attrs((props: { $height: string }) => props)`
+  height: ${(props) => props.$height ?? "0"};
+`;
+
+export default function Spacers({ width, height }: { width?: string; height?: string }): JSX.Element {
+  return width ? <Horizontal $width={width} /> : <Vertical $height={height} />;
+}

--- a/src/hooks/useSliderChange.tsx
+++ b/src/hooks/useSliderChange.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useMemo } from "react";
+import { TChannel, TChannelHSL, Irgba, Ihsla, TFormat } from "colormaster/types";
+import CM, { ColorMaster } from "colormaster";
+import HEXSliderGroup from "../components/Sliders/HEXSliderGroup";
+import HSLSliderGroup from "../components/Sliders/HSLSliderGroup";
+import RGBSliderGroup from "../components/Sliders/RGBSliderGroup";
+
+type TValidFormat = Exclude<TFormat, "name" | "invalid">;
+
+interface IUseSliderChange {
+  type: TValidFormat;
+  colorStr: string;
+  sliders: JSX.Element;
+}
+
+export default function useSliderChange(
+  color: ColorMaster,
+  setColor: React.Dispatch<React.SetStateAction<ColorMaster>>,
+  colorspace: TValidFormat,
+  alpha: boolean,
+  min?: string
+): IUseSliderChange {
+  const handleSliderChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>, type: TChannel | TChannelHSL) => {
+      const val = Number.isNaN(e.target.valueAsNumber)
+        ? e.target.value.length > 0
+          ? parseInt(e.target.value, 16)
+          : 0
+        : e.target.valueAsNumber;
+
+      const { r, g, b } = color.rgba();
+      const { h, s, l } = color.hsla();
+
+      const newColor: Irgba | Ihsla = ["red", "green", "blue"].includes(type)
+        ? { r: type === "red" ? val : r, g: type === "green" ? val : g, b: type === "blue" ? val : b, a: 1 }
+        : {
+            h: type === "hue" ? Math.max(0, Math.min(val, 359.99)) : h,
+            s: type === "saturation" ? val : s,
+            l: type === "lightness" ? val : l,
+            a: 1
+          };
+
+      newColor.a = type === "alpha" ? val / (colorspace === "hex" ? 255 : 100) : color.alpha;
+
+      setColor(CM(newColor));
+    },
+    [color, setColor, colorspace]
+  );
+
+  const currentSliderChoice = useMemo(() => {
+    const possibleSliders: IUseSliderChange[] = [
+      {
+        type: "rgb",
+        colorStr: color.stringRGB({ alpha, precision: [2, 2, 2, 2] }),
+        sliders: <RGBSliderGroup rgb={color.rgba()} onChange={handleSliderChange} />
+      },
+      {
+        type: "hex",
+        colorStr: color.stringHEX({ alpha }),
+        sliders: <HEXSliderGroup color={color} onChange={handleSliderChange} />
+      },
+      {
+        type: "hsl",
+        colorStr: color.stringHSL({ alpha, precision: [2, 2, 2, 2] }),
+        sliders: <HSLSliderGroup hsl={color.hsla()} onChange={handleSliderChange} min={min} />
+      }
+    ];
+
+    return possibleSliders.filter((slider) => slider.type === colorspace)[0];
+  }, [colorspace, color, alpha, handleSliderChange, min]);
+
+  return currentSliderChoice;
+}

--- a/src/hooks/useSliderChange.tsx
+++ b/src/hooks/useSliderChange.tsx
@@ -8,18 +8,25 @@ import RGBSliderGroup from "../components/Sliders/RGBSliderGroup";
 type TValidFormat = Exclude<TFormat, "name" | "invalid">;
 
 interface IUseSliderChange {
+  color: ColorMaster;
+  setColor: React.Dispatch<React.SetStateAction<ColorMaster>>;
+  colorspace: TValidFormat;
+  alpha?: boolean;
+  min?: string;
+}
+interface IUseSliderChangeReturn {
   type: TValidFormat;
   colorStr: string;
   sliders: JSX.Element;
 }
 
-export default function useSliderChange(
-  color: ColorMaster,
-  setColor: React.Dispatch<React.SetStateAction<ColorMaster>>,
-  colorspace: TValidFormat,
-  alpha: boolean,
-  min?: string
-): IUseSliderChange {
+export default function useSliderChange({
+  color,
+  setColor,
+  colorspace,
+  alpha,
+  min = "0"
+}: IUseSliderChange): IUseSliderChangeReturn {
   const handleSliderChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>, type: TChannel | TChannelHSL) => {
       const val = Number.isNaN(e.target.valueAsNumber)
@@ -48,7 +55,7 @@ export default function useSliderChange(
   );
 
   const currentSliderChoice = useMemo(() => {
-    const possibleSliders: IUseSliderChange[] = [
+    const possibleSliders: IUseSliderChangeReturn[] = [
       {
         type: "rgb",
         colorStr: color.stringRGB({ alpha, precision: [2, 2, 2, 2] }),

--- a/src/styles/Canvas.tsx
+++ b/src/styles/Canvas.tsx
@@ -7,10 +7,6 @@ export const CanvasContainer = styled.div.attrs(
 )`
   display: grid;
   grid-template-columns: repeat(8, 1fr);
-
-  touch-action: none;
-  background: transparent;
-
   grid-gap: 10px;
 
   & .main {
@@ -40,12 +36,14 @@ export const CanvasContainer = styled.div.attrs(
   }
 
   & canvas {
+    touch-action: none;
+    background: transparent;
     cursor: crosshair;
     border: 1px solid hsla(0, 0%, 90%, 1);
+    border-bottom: none;
 
     &.main.wheel {
       border: none;
-      border-radius: 50%;
     }
   }
 `;

--- a/src/styles/Swatch.tsx
+++ b/src/styles/Swatch.tsx
@@ -9,7 +9,7 @@ export const Swatch = styled.div.attrs(
     $borderColor: string;
     $units?: string;
     $borderRadius?: string;
-    $clickable?: boolean;
+    $cursor?: string;
   }) => ({
     ...props,
     style: { background: props.background } // this changes a lot
@@ -22,5 +22,5 @@ export const Swatch = styled.div.attrs(
   display: ${(props) => props.display ?? "block"};
   margin: auto ${(props) => (props.display ? "2px" : "auto")};
   position: ${(props) => props.position ?? ""};
-  cursor: ${(props) => (props.$clickable ? "pointer" : "help")};
+  cursor: ${(props) => props.$cursor};
 `;

--- a/src/styles/Swatch.tsx
+++ b/src/styles/Swatch.tsx
@@ -2,23 +2,23 @@ import styled from "styled-components";
 
 export const Swatch = styled.div.attrs(
   (props: {
-    radius: number;
     background: string;
-    units?: string;
-    borderColor: string;
-    borderRadius?: string;
-    display?: string;
     position?: string;
+    display?: string;
+    $radius: number;
+    $borderColor: string;
+    $units?: string;
+    $borderRadius?: string;
     $clickable?: boolean;
   }) => ({
     ...props,
     style: { background: props.background } // this changes a lot
   })
 )`
-  width: ${(props) => props.radius * 2 + (props.units ?? "px")};
-  height: ${(props) => props.radius * 2 + (props.units ?? "px")};
-  border-radius: ${(props) => props.borderRadius ?? "50%"};
-  border: ${(props) => props.borderColor ?? "hsla(0, 0%, 90%, 1)"} 1px solid;
+  width: ${(props) => props.$radius * 2 + (props.$units ?? "px")};
+  height: ${(props) => props.$radius * 2 + (props.$units ?? "px")};
+  border-radius: ${(props) => props.$borderRadius ?? "50%"};
+  border: ${(props) => props.$borderColor ?? "hsla(0, 0%, 90%, 1)"} 1px solid;
   display: ${(props) => props.display ?? "block"};
   margin: auto ${(props) => (props.display ? "2px" : "auto")};
   position: ${(props) => props.position ?? ""};

--- a/src/styles/Swatch.tsx
+++ b/src/styles/Swatch.tsx
@@ -1,3 +1,4 @@
+import { Icon, Label } from "semantic-ui-react";
 import styled from "styled-components";
 
 export const Swatch = styled.div.attrs(
@@ -23,4 +24,23 @@ export const Swatch = styled.div.attrs(
   margin: auto ${(props) => (props.display ? "2px" : "auto")};
   position: ${(props) => props.position ?? ""};
   cursor: ${(props) => props.$cursor};
+`;
+
+export const CurrentColorIcon = styled(Icon)`
+  && {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+`;
+
+export const SwatchCounter = styled(Label)`
+  && {
+    border-radius: 2px 0;
+    color: black;
+    position: absolute;
+    left: 0;
+    top: -1px;
+  }
 `;

--- a/src/styles/Swatch.tsx
+++ b/src/styles/Swatch.tsx
@@ -20,7 +20,7 @@ export const Swatch = styled.div.attrs(
   border-radius: ${(props) => props.borderRadius ?? "50%"};
   border: ${(props) => props.borderColor ?? "hsla(0, 0%, 90%, 1)"} 1px solid;
   display: ${(props) => props.display ?? "block"};
-  margin: 0 ${(props) => (props.display ? "2px" : "auto")};
+  margin: auto ${(props) => (props.display ? "2px" : "auto")};
   position: ${(props) => props.position ?? ""};
   cursor: ${(props) => (props.$clickable ? "pointer" : "help")};
 `;

--- a/src/utils/addColor.ts
+++ b/src/utils/addColor.ts
@@ -1,0 +1,14 @@
+import CM from "colormaster";
+
+type TColorMaster = ReturnType<typeof CM>;
+
+export default function addColor(c1: TColorMaster, c2: TColorMaster, isIncrement: boolean): TColorMaster {
+  const sign = isIncrement ? 1 : -1;
+  const { h, s, l, a } = c2.hsla();
+
+  const hueAlphaAdjusted = CM(c1.hsla())
+    .hueBy(sign * h)
+    .alphaBy(sign * a);
+
+  return isIncrement ? hueAlphaAdjusted.saturateBy(s).lighterBy(l) : hueAlphaAdjusted.desaturateBy(s).darkerBy(l);
+}

--- a/src/utils/codeSamples.ts
+++ b/src/utils/codeSamples.ts
@@ -68,7 +68,8 @@ export function MixSample(
   primary: ColorMaster,
   secondary: ColorMaster,
   ratio: number,
-  colorspace: Exclude<TFormat, "invalid" | "name">
+  colorspace: Exclude<TFormat, "invalid" | "name">,
+  alpha: boolean
 ): string {
   const precision = [2, 2, 2, 2] as Required<TNumArr>;
   const mix = primary.mix({ color: secondary, ratio, colorspace });
@@ -84,6 +85,6 @@ const ratio = ${ratio}; ${ratio === 0.5 ? "// default" : ""}
 const colorspace = "${colorspace}"; ${colorspace === "luv" ? "// default" : ""}
 
 const mix = primary.mix({color: secondary, ratio, colorspace});
-console.log(mix.stringHSL()); // ${mix.stringHSL()} → ${mix.name(nameOpts)}
+console.log(mix.stringHSL({ alpha: ${alpha} })); // ${mix.stringHSL({ alpha })} → ${mix.name(nameOpts)}
 `;
 }

--- a/src/utils/codeSamples.ts
+++ b/src/utils/codeSamples.ts
@@ -93,7 +93,6 @@ export function ManipulationSample(
   isIncrement: boolean,
   alpha: { [K in "adjust" | "rotate" | "invert" | "grayscale"]: boolean }
 ): string {
-  const precision = [2, 2, 2, 2] as Required<TNumArr>;
   const { h, s, l, a } = incrementColor.hsla();
   const sign = isIncrement ? 1 : -1;
 
@@ -147,6 +146,47 @@ console.log(grayscale.stringHSL({ alpha: ${alpha.grayscale} }))); // ${grayscale
     precision,
     alpha: alpha.grayscale
   })} → ${grayscale.name(nameOpts)}
+`;
+}
 
+export function A11yStatisticsSample(
+  color: ColorMaster,
+  alpha: { [K in "warm" | "cool" | "pure" | "web"]: boolean }
+): string {
+  const warm = CM(color.hsla()).closestWarm();
+  const cool = CM(color.hsla()).closestCool();
+  const pure = CM(color.hsla()).closestPureHue();
+  const web = CM(color.hsla()).closestWebSafe();
+
+  return `import CM, { extendPlugins } from 'colormaster';
+import A11yPlugin from "colormaster/plugins/accessibility";
+
+extendPlugins([A11yPlugin]); // add ColorMaster's accessibility plugin
+
+const color = CM("${color.stringHSL({ precision })}"); // ${color.name(nameOpts)}
+
+// note we use \`CM(color.hsla())\` to "deep copy" \`color\` and avoid manipulating it unintentionally
+
+const warm = CM(color.hsla()).closestWarm()
+const cool = CM(color.hsla()).closestCool()
+const pure = CM(color.hsla()).closestPureHue()
+const web = CM(color.hsla()).closestWebSafe()
+
+console.log(warm.stringHSL({ alpha: ${alpha.warm} }))); // ${warm.stringHSL({
+    precision,
+    alpha: alpha.warm
+  })} → ${warm.name(nameOpts)}
+console.log(cool.stringHSL({ alpha: ${alpha.cool} }))); // ${cool.stringHSL({
+    precision,
+    alpha: alpha.cool
+  })} → ${cool.name(nameOpts)}
+console.log(pure.stringHSL({ alpha: ${alpha.pure} }))); // ${pure.stringHSL({
+    precision,
+    alpha: alpha.pure
+  })} → ${pure.name(nameOpts)}
+console.log(web.stringHSL({ alpha: ${alpha.web} }))); // ${web.stringHSL({
+    precision,
+    alpha: alpha.web
+  })} → ${web.name(nameOpts)}
 `;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/api/(.*)", "destination": "/api" }]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "rewrites": [{ "source": "/api/(.*)", "destination": "/api" }]
+  "rewrites": [{ "source": "/api/(.*)", "destination": "/api/v1" }]
 }


### PR DESCRIPTION
## Added
- Name to `colorSelectorWidget` (below swatch - dynamically updates)
- Color display bar in `MixAnalysis`
- Custom spacer component to allow horizontal and vertical spacing of various sizes
- Utility function for combining HSL functions
- Code sample for `ManipulateAnalysis` & `A11yStatisticsAnalysis` pages
- Numbers to wheel picker when multiple pickers are present
- [Swagger](https://swagger.io/tools/swagger-ui/) API documentation
- Manipulation & Statistics API
- Color names above color indicators
- Numbered labels to each swatch and a current color indicator where applicable

## Fixed
- Contrast `GET` response → flat `readableOn` array
- `HarmonyAnalysis` jitter when selecting color

## Changed
- Moved `ContrastAnalysis` tab to be in new `Accessibility` tab dropdown (show breadcrumbs to indicate which submenu is currently active
- `ManipulationAnalysis` → `ManipulateAnalysis`
- Extracted copy color functionality to its own component
- Moved slider selection logic to `useSliderChange` hook
- Adjusted spacing in `ContrastAnalysis`. 
- Numbered all harmony types (not just monochromatic).
- Adjusted radio button row to take up whole row which avoids the jump when switching to body option
- Adjusted information in `ManipulationAnalysis` to be pop-ups for each color